### PR TITLE
Issue_6 adding security logic to support session based authentication

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@
 /target/
 **/.idea
 **/*iml
+
+# The H2 database files
+session*

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <spring.boot-version>2.1.1.RELEASE</spring.boot-version>
+    <spring.boot-version>2.2.4.RELEASE</spring.boot-version>
   </properties>
 
   <dependencyManagement>
@@ -81,6 +81,25 @@
     <dependency>
     	<groupId>com.unboundid</groupId>
     	<artifactId>unboundid-ldapsdk</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-jdbc</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.session</groupId>
+      <artifactId>spring-session-core</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.session</groupId>
+      <artifactId>spring-session-jdbc</artifactId>
+    </dependency>
+    <!-- https://mvnrepository.com/artifact/com.h2database/h2 -->
+    <dependency>
+      <groupId>com.h2database</groupId>
+      <artifactId>h2</artifactId>
+      <version>1.4.200</version>
+      <scope>runtime</scope>
     </dependency>
   </dependencies>
   <build>

--- a/src/main/java/gov/bnl/olog/Application.java
+++ b/src/main/java/gov/bnl/olog/Application.java
@@ -4,19 +4,33 @@ import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.util.FileCopyUtils;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 @SpringBootApplication
 @ComponentScan(basePackages = { "gov.bnl.olog" })
 public class Application {
     static final Logger logger = Logger.getLogger("Olog");
+
+    /**
+     * Specifies the allowed origins for CORS requests. Defaults to http://localhost:3000,
+     * which is useful during development of the web front-end in NodeJS.
+     */
+    //@Value("${cors.allowed.origins:http://localhost:3000}")
+    @Value("#{'${cors.allowed.origins:http://localhost:3000}'.split(',')}")
+    private String[] corsAllowedOrigins;
 
     public static void main(String[] args)
     {
@@ -46,5 +60,23 @@ public class Application {
             logger.log(Level.INFO, "using default javax.net.ssl.trustStorePassword");
             System.setProperty("javax.net.ssl.trustStorePassword", "changeit");
         }
+    }
+
+    /**
+     * Configures CORS policy in order to allow clients (web front-end) to do CORS requests if
+     * needed. Without a suitable configuration a client deployed to a different server than the olog-es service will not
+     * be able to request resources.
+     * Note: configuring this in {@link WebSecurityConfig#configure(HttpSecurity)}, it will have no effect. Not sure why,
+     * but probably related to the order in which Spring Security loads stuff.
+     * @return
+     */
+    @Bean
+    public WebMvcConfigurer corsConfigurer() {
+        return new WebMvcConfigurer() {
+            @Override
+            public void addCorsMappings(CorsRegistry registry) {
+                registry.addMapping("/**").allowedOrigins(corsAllowedOrigins);
+            }
+        };
     }
 }

--- a/src/main/java/gov/bnl/olog/Application.java
+++ b/src/main/java/gov/bnl/olog/Application.java
@@ -28,7 +28,6 @@ public class Application {
      * Specifies the allowed origins for CORS requests. Defaults to http://localhost:3000,
      * which is useful during development of the web front-end in NodeJS.
      */
-    //@Value("${cors.allowed.origins:http://localhost:3000}")
     @Value("#{'${cors.allowed.origins:http://localhost:3000}'.split(',')}")
     private String[] corsAllowedOrigins;
 
@@ -75,7 +74,10 @@ public class Application {
         return new WebMvcConfigurer() {
             @Override
             public void addCorsMappings(CorsRegistry registry) {
-                registry.addMapping("/**").allowedOrigins(corsAllowedOrigins);
+                registry.addMapping("/**")
+                        .allowCredentials(true)
+                        .allowedMethods("HEAD", "GET", "POST", "PUT", "DELETE", "PATCH")
+                        .allowedOrigins(corsAllowedOrigins);
             }
         };
     }

--- a/src/main/java/gov/bnl/olog/AuthenticationResource.java
+++ b/src/main/java/gov/bnl/olog/AuthenticationResource.java
@@ -118,4 +118,23 @@ public class AuthenticationResource {
         }
         return new ResponseEntity<>("", HttpStatus.OK);
     }
+
+    /**
+     * Will return the user name of the session as identified by the session cookie, or null if the
+     * request does not contain the expected cookie or if the cookie is not associated with a non-expired session.
+     * @param cookieValue
+     * @return
+     */
+    @GetMapping(value = "user")
+    public ResponseEntity<String> getCurrentUser(@CookieValue(value = WebSecurityConfig.SESSION_COOKIE_NAME, required = false) String cookieValue) {
+        if (cookieValue == null) {
+            return new ResponseEntity<>(null, HttpStatus.OK);
+        }
+        Session session = sessionRepository.findById(cookieValue);
+        if (session == null || session.isExpired()) {
+            return new ResponseEntity<>(null, HttpStatus.OK);
+        }
+        String userName = session.getAttribute(FindByIndexNameSessionRepository.PRINCIPAL_NAME_INDEX_NAME);
+        return new ResponseEntity<>(userName, HttpStatus.OK);
+    }
 }

--- a/src/main/java/gov/bnl/olog/AuthenticationResource.java
+++ b/src/main/java/gov/bnl/olog/AuthenticationResource.java
@@ -1,0 +1,121 @@
+/**
+ * Copyright (C) 2020 European Spallation Source ERIC.
+ * <p>
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * <p>
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+ */
+
+package gov.bnl.olog;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.session.FindByIndexNameSessionRepository;
+import org.springframework.session.Session;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.CookieValue;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+
+import javax.servlet.http.Cookie;
+import javax.servlet.http.HttpServletResponse;
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+
+@Controller
+@RequestMapping("/")
+public class AuthenticationResource {
+
+    @Autowired
+    private AuthenticationManager authenticationManager;
+
+    @Autowired
+    private FindByIndexNameSessionRepository sessionRepository;
+
+    @Value("${spring.session.timeout:30}")
+    private int sessionTimeout;
+
+    private ObjectMapper objectMapper = new ObjectMapper();
+
+    /**
+     * Authenticates user and creates a session if authentication is successful.
+     * A cookie named "SESSION" is created and provided in the response.
+     * This endpoint can be used by a form-based login, or a POST where username
+     * and password are specified as request parameters.
+     *
+     * @param userName The user principal name
+     * @param password User's password
+     * @param response {@link HttpServletResponse} to which a session cookie is
+     *                 attached upon successful authentication.
+     * @return A {@link ResponseEntity} indicating authentication result.
+     */
+    @PostMapping(value = "login")
+    public ResponseEntity<String> login(@RequestParam(value = "username") String userName,
+                                        @RequestParam(value = "password") String password,
+                                        HttpServletResponse response) {
+        Authentication authentication = new UsernamePasswordAuthenticationToken(userName, password);
+        try {
+            authentication = authenticationManager.authenticate(authentication);
+        } catch (AuthenticationException e) {
+            return new ResponseEntity<>(
+                    "Invalid credentials",
+                    HttpStatus.UNAUTHORIZED);
+        }
+        Session session = sessionRepository.createSession();
+        session.setMaxInactiveInterval(Duration.ofMinutes(sessionTimeout));
+        session.setAttribute(FindByIndexNameSessionRepository.PRINCIPAL_NAME_INDEX_NAME, userName);
+        List<String> roles = authentication.getAuthorities().stream()
+                .map(authority -> authority.getAuthority()).collect(Collectors.toList());
+        session.setAttribute(WebSecurityConfig.ROLES_ATTRIBUTE_NAME, roles);
+        sessionRepository.save(session);
+        Map<String, ? extends Session> sessionIds =
+                sessionRepository.findByPrincipalName(userName);
+        if (sessionIds.size() > 0) {
+            session = sessionRepository.findById(sessionIds.keySet().iterator().next());
+            Cookie cookie = new Cookie(WebSecurityConfig.SESSION_COOKIE_NAME, session.getId());
+            response.addCookie(cookie);
+
+        } else {
+            return new ResponseEntity<>(
+                    "Unable to create session for user",
+                    HttpStatus.UNAUTHORIZED);
+        }
+        return new ResponseEntity<>(
+                "",
+                HttpStatus.OK);
+    }
+
+    /**
+     * Deletes a session identified by the session cookie, if present in the request.
+     * @param cookieValue
+     */
+    @GetMapping(value = "logout")
+    public ResponseEntity<String> logout(@CookieValue(value = WebSecurityConfig.SESSION_COOKIE_NAME, required = false) String cookieValue) {
+        if (cookieValue != null) {
+            sessionRepository.deleteById(cookieValue);
+        }
+        return new ResponseEntity<>("", HttpStatus.OK);
+    }
+}

--- a/src/main/java/gov/bnl/olog/ElasticConfig.java
+++ b/src/main/java/gov/bnl/olog/ElasticConfig.java
@@ -10,12 +10,12 @@ import java.util.logging.Logger;
 import org.apache.http.HttpHost;
 import org.elasticsearch.action.admin.indices.create.CreateIndexRequest;
 import org.elasticsearch.action.admin.indices.get.GetIndexRequest;
-import org.elasticsearch.action.admin.indices.template.get.GetIndexTemplatesRequest;
-import org.elasticsearch.action.admin.indices.template.get.GetIndexTemplatesResponse;
 import org.elasticsearch.action.admin.indices.template.put.PutIndexTemplateRequest;
 import org.elasticsearch.client.RequestOptions;
 import org.elasticsearch.client.RestClient;
 import org.elasticsearch.client.RestHighLevelClient;
+import org.elasticsearch.client.indices.GetIndexTemplatesRequest;
+import org.elasticsearch.client.indices.GetIndexTemplatesResponse;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.XContentFactory;
 import org.springframework.beans.factory.annotation.Value;
@@ -182,9 +182,9 @@ public class ElasticConfig
         // create/migrate log template
         try
         {
-            GetIndexTemplatesResponse templates = indexClient.indices().getTemplate(new GetIndexTemplatesRequest("*"), RequestOptions.DEFAULT);
+            GetIndexTemplatesResponse templates = indexClient.indices().getIndexTemplate(new GetIndexTemplatesRequest("*"), RequestOptions.DEFAULT);
             if (!templates.getIndexTemplates().stream().anyMatch(i -> {
-                return i.get().getName().equalsIgnoreCase(ES_LOG_INDEX + "_template");
+                return i.name().equalsIgnoreCase(ES_LOG_INDEX + "_template");
             }))
             {
                 PutIndexTemplateRequest templateRequest = new PutIndexTemplateRequest(ES_LOG_INDEX + "_template");

--- a/src/main/java/gov/bnl/olog/LogbooksResource.java
+++ b/src/main/java/gov/bnl/olog/LogbooksResource.java
@@ -11,8 +11,11 @@ import java.security.Principal;
 import java.util.List;
 import java.util.logging.Logger;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.CrossOrigin;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;

--- a/src/main/java/gov/bnl/olog/WebSecurityConfig.java
+++ b/src/main/java/gov/bnl/olog/WebSecurityConfig.java
@@ -163,6 +163,7 @@ public class WebSecurityConfig extends WebSecurityConfigurerAdapter {
 
     /**
      * The {@link DataSource} for the session repository.
+     *
      * @return
      */
     @Bean
@@ -176,6 +177,7 @@ public class WebSecurityConfig extends WebSecurityConfigurerAdapter {
     /**
      * A session repository managing the sessions created when user logs in though the
      * dedicated endpoint.
+     *
      * @return
      */
     @Bean
@@ -197,7 +199,7 @@ public class WebSecurityConfig extends WebSecurityConfigurerAdapter {
 
     @Bean
     @Primary
-    public H2ConsoleProperties h2ConsoleProperties(){
+    public H2ConsoleProperties h2ConsoleProperties() {
         return new H2ConsoleProperties();
     }
 }

--- a/src/main/java/gov/bnl/olog/WebSecurityConfig.java
+++ b/src/main/java/gov/bnl/olog/WebSecurityConfig.java
@@ -51,12 +51,15 @@ public class WebSecurityConfig extends WebSecurityConfigurerAdapter {
 
     @Override
     public void configure(WebSecurity web) throws Exception {
+        // The below lists exceptions for authentication.
         web.ignoring().antMatchers(HttpMethod.GET, "/**");
         web.ignoring().antMatchers(HttpMethod.POST, "/login*");
         web.ignoring().antMatchers(HttpMethod.POST, "/logout");
         web.ignoring().antMatchers(HttpMethod.POST, "/user");
+        // This is needed for CORS pre-flight
+        web.ignoring().antMatchers(HttpMethod.OPTIONS, "/**");
+        // h2 database console, if enabled.
         web.ignoring().requestMatchers(PathRequest.toH2Console());
-        // Authentication and Authorization is only needed for non search/query operations
     }
 
     /**

--- a/src/main/java/gov/bnl/olog/WebSecurityConfig.java
+++ b/src/main/java/gov/bnl/olog/WebSecurityConfig.java
@@ -53,7 +53,8 @@ public class WebSecurityConfig extends WebSecurityConfigurerAdapter {
     public void configure(WebSecurity web) throws Exception {
         web.ignoring().antMatchers(HttpMethod.GET, "/**");
         web.ignoring().antMatchers(HttpMethod.POST, "/login*");
-        web.ignoring().antMatchers(HttpMethod.POST, "/logout*");
+        web.ignoring().antMatchers(HttpMethod.POST, "/logout");
+        web.ignoring().antMatchers(HttpMethod.POST, "/user");
         web.ignoring().requestMatchers(PathRequest.toH2Console());
         // Authentication and Authorization is only needed for non search/query operations
     }

--- a/src/main/java/gov/bnl/olog/entity/UserData.java
+++ b/src/main/java/gov/bnl/olog/entity/UserData.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (C) 2020 European Spallation Source ERIC.
+ *
+ *  This program is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU General Public License
+ *  as published by the Free Software Foundation; either version 2
+ *  of the License, or (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program; if not, write to the Free Software
+ *  Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+ */
+
+package gov.bnl.olog.entity;
+
+import java.util.List;
+
+/**
+ * Simple pojo used to convey user name and list of roles to a client upon
+ * login or explicit request, see {@link gov.bnl.olog.AuthenticationResource}.
+ */
+public class UserData {
+
+    private String userName;
+    private List<String> roles;
+
+    public UserData(){
+
+    }
+
+    public UserData(String userName, List<String> roles){
+        this.userName = userName;
+        this.roles = roles;
+    }
+
+    public String getUserName() {
+        return userName;
+    }
+
+    public void setUserName(String userName) {
+        this.userName = userName;
+    }
+
+    public List<String> getRoles() {
+        return roles;
+    }
+
+    public void setRoles(List<String> roles) {
+        this.roles = roles;
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -102,7 +102,9 @@ mongo.port:27017
 ############################## Spring Session repository configuration ##############################
 
 # For debugging purposes, set the below to true
-#spring.h2.console.enabled=true
+spring.h2.console.enabled=true
+# Sets the maximum inactive interval, in minutes. Defaults to 30 if not set here.
+# spring.session.timeout=30
 
 ############################## CORS settings ##############################
 # Comma separated list of origins allowed to do CORS requests.

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -102,6 +102,10 @@ mongo.port:27017
 ############################## Spring Session repository configuration ##############################
 
 # For debugging purposes, set the below to true
-spring.h2.console.enabled=true
+#spring.h2.console.enabled=true
 
-
+############################## CORS settings ##############################
+# Comma separated list of origins allowed to do CORS requests.
+# Defaults to http://localhost:3000 (NodeJS development), but must be augmented
+# with the origin(s) on which the web front-end is deployed.
+#cors.allowed.origins=http://localhost:3000

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -15,6 +15,7 @@ logging.level.org.springframework=INFO
 logging.level.org.apache.catalina=INFO
 logging.level.org.apache.kafka=INFO
 logging.level.org.springframework.web=INFO
+logging.level.org.springframework.security=INFO
 
 spring.main.allow-bean-definition-overriding=true
 
@@ -96,3 +97,11 @@ elasticsearch.sequence.type: olog_sequence
 mongo.database:ologAttachments
 mongo.host:localhost
 mongo.port:27017
+
+
+############################## Spring Session repository configuration ##############################
+
+# For debugging purposes, set the below to true
+spring.h2.console.enabled=true
+
+

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -102,7 +102,7 @@ mongo.port:27017
 ############################## Spring Session repository configuration ##############################
 
 # For debugging purposes, set the below to true
-spring.h2.console.enabled=true
+# spring.h2.console.enabled=true
 # Sets the maximum inactive interval, in minutes. Defaults to 30 if not set here.
 # spring.session.timeout=30
 

--- a/src/test/java/gov/bnl/olog/AuthenticationResourceTest.java
+++ b/src/test/java/gov/bnl/olog/AuthenticationResourceTest.java
@@ -81,6 +81,15 @@ public class AuthenticationResourceTest extends ResourcesTestBase {
         assertEquals("admin", userData.getUserName());
         assertNotNull(userData.getRoles());
 
+        // Log in again and verify that the cookie value is the same, i.e. same session on server.
+        when(mockAuthentication.getAuthorities()).thenReturn(authorities);
+        when(authenticationManager.authenticate(authentication)).thenReturn(mockAuthentication);
+        request = post("/login?username=admin&password=adminPass");
+        result = mockMvc.perform(request).andExpect(status().isOk())
+                .andReturn();
+        Cookie cookie2 = result.getResponse().getCookie("SESSION");
+        assertEquals(cookie.getValue(), cookie2.getValue());
+
         request = get("/user").cookie(cookie);
         result = mockMvc.perform(request).andExpect(status().isOk())
                 .andReturn();

--- a/src/test/java/gov/bnl/olog/AuthenticationResourceTest.java
+++ b/src/test/java/gov/bnl/olog/AuthenticationResourceTest.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright (C) 2020 European Spallation Source ERIC.
+ *
+ *  This program is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU General Public License
+ *  as published by the Free Software Foundation; either version 2
+ *  of the License, or (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program; if not, write to the Free Software
+ *  Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+ */
+
+package gov.bnl.olog;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.ContextHierarchy;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.test.web.servlet.RequestBuilder;
+import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
+
+import javax.servlet.http.Cookie;
+import java.util.HashSet;
+import java.util.Set;
+
+import static org.junit.Assert.assertNotNull;
+import static org.mockito.Mockito.*;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestBuilders.formLogin;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.cookie;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@RunWith(SpringRunner.class)
+@ContextHierarchy({@ContextConfiguration(classes = {AuthenticationResourceTestConfig.class})})
+@WebMvcTest(AuthenticationResourceTest.class)
+@TestPropertySource(locations = "classpath:no_ldap_test_application.properties")
+public class AuthenticationResourceTest extends ResourcesTestBase {
+
+
+    @Autowired
+    private AuthenticationManager authenticationManager;
+
+    @Test
+    public void testSuccessfullLogin() throws Exception {
+        SimpleGrantedAuthority authority = new SimpleGrantedAuthority("ROLE_ADMIN");
+        Authentication mockAuthentication = mock(Authentication.class);
+        Set authorities = new HashSet();
+        authorities.add(authority);
+        when(mockAuthentication.getAuthorities()).thenReturn(authorities);
+        Authentication authentication = new UsernamePasswordAuthenticationToken("admin", "adminPass");
+        when(authenticationManager.authenticate(authentication)).thenReturn(mockAuthentication);
+        MockHttpServletRequestBuilder request = post("/login?username=admin&password=adminPass");
+        MvcResult result = mockMvc.perform(request).andExpect(status().isOk())
+                .andReturn();
+        assertNotNull(result.getResponse().getCookie("SESSION"));
+        reset(authenticationManager);
+    }
+
+    @Test
+    public void testSuccessfullFormLogin() throws Exception {
+        SimpleGrantedAuthority authority = new SimpleGrantedAuthority("ROLE_ADMIN");
+        Authentication mockAuthentication = mock(Authentication.class);
+        Set authorities = new HashSet();
+        authorities.add(authority);
+        when(mockAuthentication.getAuthorities()).thenReturn(authorities);
+        Authentication authentication = new UsernamePasswordAuthenticationToken("admin", "adminPass");
+        when(authenticationManager.authenticate(authentication)).thenReturn(mockAuthentication);
+        RequestBuilder requestBuilder = formLogin().user("admin").password("adminPass");
+        mockMvc.perform(requestBuilder)
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(cookie().exists("SESSION"));
+        reset(authenticationManager);
+    }
+
+    @Test
+    public void testFailedLogin() throws Exception {
+        doThrow(new BadCredentialsException("bad")).when(authenticationManager).authenticate(any(Authentication.class));
+        MockHttpServletRequestBuilder request = post("/login?username=admin&password=badPass");
+        mockMvc.perform(request).andExpect(status().isUnauthorized());
+        reset(authenticationManager);
+    }
+
+    @Test
+    public void testLogout() throws Exception {
+        MockHttpServletRequestBuilder request = get("/logout");
+        mockMvc.perform(request).andExpect(status().isOk());
+
+        get("/logout").cookie(new Cookie("SESSION", "abc"));
+        mockMvc.perform(request).andExpect(status().isOk());
+    }
+}

--- a/src/test/java/gov/bnl/olog/AuthenticationResourceTestConfig.java
+++ b/src/test/java/gov/bnl/olog/AuthenticationResourceTestConfig.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (C) 2020 European Spallation Source ERIC.
+ *
+ *  This program is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU General Public License
+ *  as published by the Free Software Foundation; either version 2
+ *  of the License, or (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program; if not, write to the Free Software
+ *  Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+ */
+
+package gov.bnl.olog;
+
+import org.mockito.Mockito;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.jdbc.core.JdbcOperations;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.datasource.DataSourceTransactionManager;
+import org.springframework.jdbc.datasource.embedded.EmbeddedDatabaseBuilder;
+import org.springframework.jdbc.datasource.embedded.EmbeddedDatabaseType;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
+import org.springframework.session.FindByIndexNameSessionRepository;
+import org.springframework.session.jdbc.JdbcIndexedSessionRepository;
+import org.springframework.transaction.support.TransactionOperations;
+import org.springframework.transaction.support.TransactionTemplate;
+
+import javax.sql.DataSource;
+
+@TestConfiguration
+public class AuthenticationResourceTestConfig {
+
+    @Bean
+    public AuthenticationManager authenticationManager() {
+        return Mockito.mock(AuthenticationManager.class);
+    }
+
+    @Bean
+    public DataSource dataSource() {
+        return new EmbeddedDatabaseBuilder()
+                .setType(EmbeddedDatabaseType.H2)
+                .addScript("org/springframework/session/jdbc/schema-h2.sql")
+                .build();
+    }
+
+    /**
+     * Not a mock in order to save us from configuring a mock to return sensible results. This
+     * is facilitated by the fact that the underlying database is in-memory H2.
+     * @return
+     */
+    @Bean
+    public FindByIndexNameSessionRepository sessionRepository() {
+        JdbcOperations jdbcOperations = new JdbcTemplate(dataSource());
+        TransactionOperations transactionOperations =
+                new TransactionTemplate(new DataSourceTransactionManager(dataSource()));
+
+        return new JdbcIndexedSessionRepository(jdbcOperations, transactionOperations);
+    }
+}

--- a/src/test/java/gov/bnl/olog/LogResourceTest.java
+++ b/src/test/java/gov/bnl/olog/LogResourceTest.java
@@ -23,7 +23,9 @@ import gov.bnl.olog.entity.Level;
 import gov.bnl.olog.entity.Log;
 import gov.bnl.olog.entity.Log.LogBuilder;
 import gov.bnl.olog.entity.Logbook;
+import org.junit.After;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.ArgumentMatcher;
@@ -42,6 +44,7 @@ import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 
+import javax.sql.DataSource;
 import java.time.Instant;
 import java.util.Arrays;
 import java.util.Optional;

--- a/src/test/java/gov/bnl/olog/LogbookResourceTest.java
+++ b/src/test/java/gov/bnl/olog/LogbookResourceTest.java
@@ -48,18 +48,20 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
  * Tests {@link Logbook} resource endpoints. The authentication scheme used is the
  * hard coded user/userPass credentials. The {@link LogbookRepository} is mocked.
  */
+
 @RunWith(SpringRunner.class)
 @ContextHierarchy({@ContextConfiguration(classes = {ResourcesTestConfig.class})})
 @WebMvcTest(LogbookResourceTest.class)
 @TestPropertySource(locations = "classpath:no_ldap_test_application.properties")
 @ActiveProfiles({"test"})
-public class LogbookResourceTest extends ResourcesTestBase{
+public class LogbookResourceTest extends ResourcesTestBase {
 
     @Autowired
     private LogbookRepository logbookRepository;
 
     private Logbook logbook1;
     private Logbook logbook2;
+
 
     @Before
     public void init() {
@@ -159,7 +161,7 @@ public class LogbookResourceTest extends ResourcesTestBase{
                 .contentType(JSON);
         MvcResult result = mockMvc.perform(request).andExpect(status().isOk()).andReturn();
         logbooks = objectMapper.readValue(result.getResponse().getContentAsString(),
-                new TypeReference<Iterable<Logbook>>() {
+                new TypeReference<List<Logbook>>() {
                 });
         assertEquals("name1", logbooks.iterator().next().getName());
         verify(logbookRepository, times(1)).saveAll(logbooks);
@@ -167,7 +169,7 @@ public class LogbookResourceTest extends ResourcesTestBase{
     }
 
     @Test
-    public void testDeleteUnauthorized() throws Exception{
+    public void testDeleteUnauthorized() throws Exception {
         MockHttpServletRequestBuilder request = delete("/" +
                 OlogResourceDescriptors.LOGBOOK_RESOURCE_URI +
                 "/name1");
@@ -175,7 +177,7 @@ public class LogbookResourceTest extends ResourcesTestBase{
     }
 
     @Test
-    public void testDelete() throws Exception{
+    public void testDelete() throws Exception {
         MockHttpServletRequestBuilder request = delete("/" +
                 OlogResourceDescriptors.LOGBOOK_RESOURCE_URI +
                 "/name1")

--- a/src/test/java/gov/bnl/olog/PropertiesResourceTest.java
+++ b/src/test/java/gov/bnl/olog/PropertiesResourceTest.java
@@ -20,13 +20,22 @@ package gov.bnl.olog;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import gov.bnl.olog.entity.Property;
+import jdk.jfr.DataAmount;
+import org.junit.After;
+import org.junit.AfterClass;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.ArgumentMatcher;
+import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.http.HttpHeaders;
+import org.springframework.mock.web.MockHttpSession;
+import org.springframework.session.FindByIndexNameSessionRepository;
+import org.springframework.session.Session;
+import org.springframework.session.jdbc.config.annotation.web.http.JdbcHttpSessionConfiguration;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.ContextHierarchy;
@@ -35,6 +44,8 @@ import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
 
+import javax.servlet.http.Cookie;
+import javax.sql.DataSource;
 import java.util.Arrays;
 import java.util.Optional;
 
@@ -120,8 +131,10 @@ public class PropertiesResourceTest extends ResourcesTestBase {
 
     @Test
     public void testUpdatePropertyUnauthoroized() throws Exception{
+
         MockHttpServletRequestBuilder request = put("/" +
-                OlogResourceDescriptors.PROPERTY_RESOURCE_URI);
+                OlogResourceDescriptors.PROPERTY_RESOURCE_URI)
+                .session(new MockHttpSession());
         mockMvc.perform(request).andExpect(status().isUnauthorized());
     }
 

--- a/src/test/java/gov/bnl/olog/ResourcesTestConfig.java
+++ b/src/test/java/gov/bnl/olog/ResourcesTestConfig.java
@@ -21,68 +21,85 @@ package gov.bnl.olog;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.elasticsearch.client.RestHighLevelClient;
 import org.mockito.Mockito;
-import org.springframework.boot.SpringBootConfiguration;
+import org.springframework.boot.autoconfigure.h2.H2ConsoleProperties;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 import org.springframework.context.annotation.Profile;
-import org.springframework.data.annotation.Id;
 import org.springframework.data.mongodb.gridfs.GridFsOperations;
 import org.springframework.data.mongodb.gridfs.GridFsTemplate;
-import org.springframework.test.context.TestPropertySource;
+import org.springframework.jdbc.datasource.embedded.EmbeddedDatabaseBuilder;
+import org.springframework.jdbc.datasource.embedded.EmbeddedDatabaseType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.PlatformTransactionManager;
 import org.springframework.web.servlet.config.annotation.EnableWebMvc;
+
+import javax.sql.DataSource;
 
 @TestConfiguration
 @EnableWebMvc
-@ComponentScan(basePackages = "gov.bnl.olog")
-@Import({WebSecurityConfig.class})
-@Profile({ "test" })
+@Import(WebSecurityConfig.class)
 public class ResourcesTestConfig {
 
     @Bean
-    public LogbookRepository logbookRepository(){
+    public LogbookRepository logbookRepository() {
         return Mockito.mock(LogbookRepository.class);
     }
 
     @Bean
-    public PropertyRepository propertyRepository(){
+    public PropertyRepository propertyRepository() {
         return Mockito.mock(PropertyRepository.class);
     }
 
     @Bean
-    public LogRepository logRepository(){
+    public LogRepository logRepository() {
         return Mockito.mock(LogRepository.class);
     }
 
     @Bean
-    public AttachmentRepository attachmentRepository(){
+    public AttachmentRepository attachmentRepository() {
         return Mockito.mock(AttachmentRepository.class);
     }
 
     @Bean("indexClient")
-    public RestHighLevelClient client(){
+    public RestHighLevelClient client() {
         return Mockito.mock(RestHighLevelClient.class);
     }
 
     @Bean
-    public GridFsOperations gridOperation(){
+    public GridFsOperations gridOperation() {
         return Mockito.mock(GridFsOperations.class);
     }
 
     @Bean
-    public GridFsTemplate gridFsTemplate(){
+    public GridFsTemplate gridFsTemplate() {
         return Mockito.mock(GridFsTemplate.class);
     }
 
     @Bean
-    public LogSearchUtil logSearchUtil(){
+    public LogSearchUtil logSearchUtil() {
         return Mockito.mock(LogSearchUtil.class);
     }
 
     @Bean
-    public ObjectMapper objectMapper(){
+    public ObjectMapper objectMapper() {
         return new ObjectMapper();
+    }
+
+
+    @Bean
+    public PlatformTransactionManager platformTransactionManager() {
+        return Mockito.mock(PlatformTransactionManager.class);
+    }
+
+    @Bean
+    public DataSource dataSource(){
+        return Mockito.mock(DataSource.class);
+    }
+
+    @Bean
+    public H2ConsoleProperties h2ConsoleProperties() {
+        return Mockito.mock(H2ConsoleProperties.class);
     }
 }


### PR DESCRIPTION
The solution is based on a servlet filter that will look for a session cookie or basic authentication header  in order to establish whether the request is allowed or not. Using a session cookie will be more efficient as a remote authentication service need not be called.

Also added a controller providing a login endpoint. Successful login will create a session and return a cookie to the client, which should use it in subsequent requests. A logout endpoint can be called to delete the session.

Sessions are managed in a H2 in-memory database. In this first version of the session management this in-memory solution means that a service restart will wipe all sessions. Extending to a file-based H2 database should be straight forward. 

In order to use the Spring JdbcIndexedSessionRepository an update of the Spring Boot dependencies were needed (2.1.1 -> 2.2.4), which in turn requires some changes when calling Elastic APIs. Basic testing does not indicate any issues.