### PR TITLE
Issue_15 Add title to the olog template

### DIFF
--- a/src/main/java/gov/bnl/olog/entity/Log.java
+++ b/src/main/java/gov/bnl/olog/entity/Log.java
@@ -35,6 +35,7 @@ public class Log implements Serializable
 
     private String source;
     private String description;
+    private String title;
 
     private Level level = Level.Info;
     private State state = State.Active;
@@ -58,23 +59,12 @@ public class Log implements Serializable
     {
     }
 
-    private Log(Long id, String version, String owner, String source, String description, Level level, State state,
-            List<Event> events, Set<Logbook> logbooks, Set<Tag> tags, Set<Property> properties)
-    {
+    public String getTitle(){
+        return title;
+    }
 
-        super();
-        this.id = id;
-        this.owner = owner;
-        this.source = source;
-        this.description = description;
-        this.level = level;
-        this.state = state;
-
-        this.events = events;
-
-        this.logbooks = logbooks;
-        this.tags = tags;
-        this.properties = properties;
+    public void setTitle(String title){
+        this.title = title;
     }
 
     /**
@@ -391,6 +381,7 @@ public class Log implements Serializable
         private String owner;
         private StringBuilder source = new StringBuilder();
         private StringBuilder description = new StringBuilder();
+        private StringBuilder title = new StringBuilder();
 
         private Level level = Level.Info;
         private State state = State.Active;
@@ -422,6 +413,7 @@ public class Log implements Serializable
                 this.source = new StringBuilder();
             }
             this.description = new StringBuilder(log.getDescription());
+            this.title = new StringBuilder(log.getTitle());
             this.level = log.getLevel();
             this.state = log.getState();
 
@@ -486,6 +478,15 @@ public class Log implements Serializable
             if (description != null)
             {
                 this.description = new StringBuilder(description);
+            }
+            return this;
+        }
+
+        public LogBuilder title(String title)
+        {
+            if (title != null)
+            {
+                this.title = new StringBuilder(title);
             }
             return this;
         }
@@ -607,6 +608,7 @@ public class Log implements Serializable
             }
             log.setEvents(events);
             log.setDescription(this.description.toString());
+            log.setTitle(this.title.toString());
             log.setSource(this.source.toString());
             log.setLevel(level);
             log.setState(state);

--- a/src/main/resources/log_template_mapping_with_title.json
+++ b/src/main/resources/log_template_mapping_with_title.json
@@ -1,0 +1,98 @@
+{
+    "properties": {
+        "id": {
+            "type": "keyword"
+        },
+        "owner": {
+            "type": "keyword"
+        },
+        "source": {
+            "type": "text"
+        },
+        "description": {
+            "type": "text"
+        },
+        "level": {
+            "type": "text"
+        },
+        "title" : {
+            "type": "text"
+        },
+        "state": {
+            "type": "keyword"
+        },
+        "createdDate": {
+            "type": "date",
+            "format": "epoch_millis||yyyy-MM-dd HH:mm:ss.SSS"
+        },
+        "modifyDate": {
+            "type": "date",
+            "format": "epoch_millis||yyyy-MM-dd HH:mm:ss.SSS"
+        },
+        "events": {
+            "type": "nested",
+            "properties": {
+                "name": {
+                    "type": "keyword"
+                },
+                "event": {
+                    "type": "date",
+                    "format": "epoch_millis||yyyy-MM-dd HH:mm:ss.SSS"
+                }
+            }
+        },
+        "logbooks": {
+            "type": "nested",
+            "properties": {
+                "name": {
+                    "type": "keyword"
+                },
+                "owner": {
+                    "type": "keyword"
+                },
+                "state": {
+                    "type": "keyword"
+                }
+            }
+        },
+        "tags": {
+            "type": "nested",
+            "properties": {
+                "name": {
+                    "type": "keyword"
+                },
+                "state": {
+                    "type": "keyword"
+                }
+            }
+        },
+        "properties": {
+            "type": "nested",
+            "properties": {
+                "name": {
+                    "type": "keyword"
+                },
+                "owner": {
+                    "type": "keyword"
+                },
+                "state": {
+                    "type": "keyword"
+                },
+                "attributes": {
+                    "type": "nested",
+                    "properties": {
+                        "name": {
+                            "type": "keyword"
+                        },
+                        "value": {
+                            "type": "keyword"
+                        },
+                        "state": {
+                            "type": "keyword"
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/test/java/gov/bnl/olog/LogRepositorySearchIT.java
+++ b/src/test/java/gov/bnl/olog/LogRepositorySearchIT.java
@@ -79,6 +79,30 @@ public class LogRepositorySearchIT  implements TestExecutionListener
                                                          new HashSet<Attribute>(List.of(testAttribute1)));
 
     /**
+     * Search by title
+     */
+    @Test
+    public void searchByTitle(){
+        MultiValueMap<String, String> searchParameters = new LinkedMultiValueMap<String, String>();
+        searchParameters.put("title", List.of("title2"));
+        List<Log> foundLogs = logRepository.search(searchParameters);
+        assertTrue("Failed to search for log entries based on title.",
+                foundLogs.size() == 1 && foundLogs.contains(createdLog2));
+
+        searchParameters = new LinkedMultiValueMap<String, String>();
+        searchParameters.put("title", List.of("le"));
+        foundLogs = logRepository.search(searchParameters);
+        assertTrue("Failed to search for log entries based on title.",
+                foundLogs.size() == 1 && foundLogs.contains(createdLog1));
+
+        searchParameters = new LinkedMultiValueMap<String, String>();
+        searchParameters.put("title", List.of("tit*"));
+        foundLogs = logRepository.search(searchParameters);
+        assertTrue("Failed to search for log entries based on title.",
+                foundLogs.size() == 2 && foundLogs.contains(createdLog1) && foundLogs.contains(createdLog2));
+    }
+
+    /**
      * Search for a particular word
      */
     @Test
@@ -405,8 +429,10 @@ public class LogRepositorySearchIT  implements TestExecutionListener
 
     private String description1 = "The quick brown fox jumps over the lazy dog";
     private String source1 = "The quick brown *fox* jumps over the lazy *dog*";
+    private String title1 = "tit le";
     private String description2 = "The quick brown foxes jumped over the lazy dogs";
     private String source2 = "The quick brown *foxes* jumped over the lazy *dogs*";
+    private String title2 = "title2";
     
 
     private String description3 = "some random test text for log entry 3";
@@ -444,6 +470,7 @@ public class LogRepositorySearchIT  implements TestExecutionListener
                                  .owner(testOwner1)
                                  .appendDescription(description1)
                                  .source(source1)
+                                 .title(title1)
                                  .withLogbook(testLogbook1)
                                  .withTag(testTag1)
                                  .withProperty(testProperty1)
@@ -460,6 +487,7 @@ public class LogRepositorySearchIT  implements TestExecutionListener
         Log log2 = Log.LogBuilder.createLog()
                                  .owner(testOwner2)
                                  .description(description2)
+                                 .title(title2)
                                  .source(source2)
                                  .withLogbook(testLogbook2)
                                  .withTag(testTag2)


### PR DESCRIPTION
Addition of title is done as a second step in ElasticConfig, which also adds a version number to the template. Verified on existing template as well as on new template (create = true). The two step procedure mimics FlyWay in a sense.

Integration tests seem to run, including search on title.

