### PR TITLE
Issue_19 Synchronized attachement upload end point

### DIFF
--- a/src/main/java/gov/bnl/olog/LogResource.java
+++ b/src/main/java/gov/bnl/olog/LogResource.java
@@ -119,10 +119,10 @@ public class LogResource
     }
 
     @PostMapping("/attachments/{logId}")
-    public Log createLog(@PathVariable String logId,
+    public synchronized Log createLog(@PathVariable String logId,
                          @RequestPart("file") MultipartFile file,
                          @RequestPart("filename") String filename,
-                         @RequestPart("fileMetadataDescription") String fileMetadataDescription) {
+                         @RequestPart(value = "fileMetadataDescription", required = false) String fileMetadataDescription) {
         Optional<Log> foundLog = logRepository.findById(logId);
         if (logRepository.findById(logId).isPresent())
         {

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -111,3 +111,8 @@ mongo.port:27017
 # Defaults to http://localhost:3000 (NodeJS development), but must be augmented
 # with the origin(s) on which the web front-end is deployed.
 #cors.allowed.origins=http://localhost:3000
+
+################## File upload and request size limits ##################
+spring.servlet.multipart.max-file-size=50MB
+# -1 means infinite
+spring.servlet.multipart.max-request-size=-1 


### PR DESCRIPTION
Also added application properties to override default file upload and request size as these limit the upload size to 1MB per file.