### PR TITLE
Adding parsing of date/time expressions

### DIFF
--- a/src/main/java/gov/bnl/olog/LogResource.java
+++ b/src/main/java/gov/bnl/olog/LogResource.java
@@ -6,9 +6,12 @@
 package gov.bnl.olog;
 
 import static gov.bnl.olog.OlogResourceDescriptors.LOG_RESOURCE_URI;
+import static org.phoebus.util.time.TimestampFormats.MILLI_FORMAT;
 
 import java.io.IOException;
 import java.security.Principal;
+import java.time.Instant;
+import java.time.temporal.TemporalAmount;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
@@ -19,6 +22,7 @@ import java.util.stream.Collectors;
 
 import gov.bnl.olog.entity.Tag;
 import org.apache.commons.collections4.CollectionUtils;
+import org.phoebus.util.time.TimeParser;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.io.InputStreamResource;
 import org.springframework.core.io.Resource;
@@ -110,8 +114,28 @@ public class LogResource
         return null;
     }
 
+    /**
+     * Finds matching log entries based on the specified search parameters.
+     * @param allRequestParams A map of search query parameters. Note that this method supports date/time expressions
+     *                         like "12 hours" or "2 days" as well as formatted strings like "2021-01-20 12:00:00.123".
+     * @return A {@link List} of {@link Log} objects matching the query parameters, or an
+     *  empty list if no matching logs are found.
+     */
     @GetMapping()
     public List<Log> findLogs(@RequestParam MultiValueMap<String, String> allRequestParams) {
+        for(String key : allRequestParams.keySet()){
+            if("start".equalsIgnoreCase(key.toLowerCase()) || "end".equalsIgnoreCase(key.toLowerCase())){
+                String value = allRequestParams.get(key).get(0);
+                Object time = TimeParser.parseInstantOrTemporalAmount(value);
+                if (time instanceof Instant) {
+                    allRequestParams.get(key).clear();
+                    allRequestParams.get(key).add(MILLI_FORMAT.format((Instant)time));
+                } else if (time instanceof TemporalAmount) {
+                    allRequestParams.get(key).clear();
+                    allRequestParams.get(key).add(MILLI_FORMAT.format(Instant.now().minus((TemporalAmount)time)));
+                }
+            }
+        }
         return logRepository.search(allRequestParams);
     }
     

--- a/src/main/java/org/phoebus/util/time/TimeInterval.java
+++ b/src/main/java/org/phoebus/util/time/TimeInterval.java
@@ -1,0 +1,155 @@
+/**
+ * Copyright (C) 2010-14 diirt developers. See COPYRIGHT.TXT
+ * All rights reserved. Use is subject to license terms. See LICENSE.TXT
+ */
+package org.phoebus.util.time;
+
+import java.time.Duration;
+import java.time.Instant;
+
+/**
+ * A period of time that spans two instances (included) at the nanosecond
+ * precision.
+ *
+ * @author carcassi
+ */
+public class TimeInterval {
+
+    private final Instant start;
+    private final Instant end;
+
+    private TimeInterval(Instant start, Instant end) {
+        this.start = start;
+        this.end = end;
+    }
+
+    /**
+     * True if the given time stamp is inside the interval.
+     *
+     * @param instant a time stamp
+     * @return true if inside the interval
+     */
+    public boolean contains(Instant instant) {
+        return (start == null || start.compareTo(instant) <= 0) && (end == null || end.compareTo(instant) >= 0);
+    }
+
+    /**
+     * Returns the interval between the given timestamps.
+     *
+     * @param start the beginning of the interval
+     * @param end the end of the interval
+     * @return a new interval
+     */
+    public static TimeInterval between(Instant start, Instant end) {
+        return new TimeInterval(start, end);
+    }
+
+    /**
+     * Returns a new interval shifted backward in time by the given duration.
+     *
+     * @param duration a time duration
+     * @return the new shifted interval
+     */
+    public TimeInterval minus(Duration duration) {
+        return between(start.minus(duration), end.minus(duration));
+    }
+
+    /**
+     * Returns a time interval that lasts this duration and is centered
+     * around the given instant reference.
+     *
+     * @param duration the duration
+     * @param reference a instant
+     * @return a new time interval
+     */
+    public static TimeInterval around(Duration duration, Instant reference) {
+        Duration half = duration.dividedBy(2);
+        return TimeInterval.between(reference.minus(half), reference.plus(half));
+    }
+
+    /**
+     * Returns a time interval that lasts this duration and starts from the
+     * given instant.
+     *
+     * @param duration the duration
+     * @param reference a instant
+     * @return a new time interval
+     */
+    public static TimeInterval after(Duration duration, Instant reference) {
+        return TimeInterval.between(reference, reference.plus(duration));
+    }
+
+    /**
+     * Returns a time interval that lasts this duration and ends at the
+     * given instant.
+     *
+     * @param duration the duration
+     * @param reference a instant
+     * @return a new time interval
+     */
+    public static TimeInterval before(Duration duration, Instant reference) {
+        return TimeInterval.between(reference.minus(duration), reference);
+    }
+
+    /**
+     * Initial value of the interval.
+     *
+     * @return the initial instant
+     */
+    public Instant getStart() {
+        return start;
+    }
+
+    /**
+     * Final value of the interval.
+     *
+     * @return the final instant
+     */
+    public Instant getEnd() {
+        return end;
+    }
+
+    @Override
+    public String toString() {
+        return String.valueOf(start) + " - " + String.valueOf(end);
+    }
+
+    /* (non-Javadoc)
+     * @see java.lang.Object#hashCode()
+     */
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + ((end == null) ? 0 : end.hashCode());
+        result = prime * result + ((start == null) ? 0 : start.hashCode());
+        return result;
+    }
+
+    /* (non-Javadoc)
+     * @see java.lang.Object#equals(java.lang.Object)
+     */
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj)
+            return true;
+        if (obj == null)
+            return false;
+        if (!(obj instanceof TimeInterval))
+            return false;
+        TimeInterval other = (TimeInterval) obj;
+        if (end == null) {
+            if (other.end != null)
+                return false;
+        } else if (!end.equals(other.end))
+            return false;
+        if (start == null) {
+            if (other.start != null)
+                return false;
+        } else if (!start.equals(other.start))
+            return false;
+        return true;
+    }
+
+
+}

--- a/src/main/java/org/phoebus/util/time/TimeParser.java
+++ b/src/main/java/org/phoebus/util/time/TimeParser.java
@@ -1,0 +1,279 @@
+/**
+ * Copyright (C) 2010-14 diirt developers. See COPYRIGHT.TXT
+ * All rights reserved. Use is subject to license terms. See LICENSE.TXT
+ */
+package org.phoebus.util.time;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.time.Period;
+import java.time.temporal.ChronoUnit;
+import java.time.temporal.TemporalAmount;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import static java.time.temporal.ChronoUnit.DAYS;
+import static java.time.temporal.ChronoUnit.HOURS;
+import static java.time.temporal.ChronoUnit.MICROS;
+import static java.time.temporal.ChronoUnit.MILLIS;
+import static java.time.temporal.ChronoUnit.MINUTES;
+import static java.time.temporal.ChronoUnit.MONTHS;
+import static java.time.temporal.ChronoUnit.SECONDS;
+import static java.time.temporal.ChronoUnit.WEEKS;
+import static java.time.temporal.ChronoUnit.YEARS;
+
+/**
+ * A helper class to parse user defined time strings to absolute or relative
+ * time durations.
+ *
+ * @author shroffk
+ */
+@SuppressWarnings("nls")
+public class TimeParser {
+    /** Text for the relative {@link TemporalAmount} of size 0 */
+    public static final String NOW = "now";
+
+    static final Pattern durationTimeQunatityUnitsPattern = Pattern
+            .compile("\\s*(\\d*)\\s*(ms|milli|sec|secs|min|mins|hour|hours|day|days)\\s*", Pattern.CASE_INSENSITIVE);
+
+    // SPACE*  (NUMBER?) SPACE*  (UNIT),
+    // with NUMBER being positive floating point
+    // Patterns need to be listed longest-first.
+    // Otherwise "days" would match just the "d"
+    static final Pattern timeQuantityUnitsPattern = Pattern.compile(
+            "\\s*([0-9]*\\.?[0-9]*)\\s*(millis|ms|seconds|second|secs|sec|s|minutes|minute|mins|min|hours|hour|h|days|day|d|weeks|week|w|months|month|mon|mo|years|year|y)\\s*",
+            Pattern.CASE_INSENSITIVE);
+
+    /** Parse a temporal amount like "1 month 2 days" or "1 day 20 seconds"
+     *
+     *  <p>Provides either a time-based {@link Duration}
+     *  or a calendar based {@link Period}.
+     *
+     *  <p>A period of "1 months" does not have a well defined
+     *  length in time because a months could have 28 to 31 days.
+     *  When the user specifies "1 month" we assume that
+     *  a time span between the same day in different months
+     *  is requested.
+     *  As soon as the time span includes a month or year,
+     *  a {@link Period} is returned and the smaller units
+     *  from hours down are ignored.
+     *
+     *  <p>For time spans that only include days or less,
+     *  a {@link Duration} is used.
+     *
+     *  @param string Text
+     *  @return {@link Duration} or {@link Period}
+     */
+    public static TemporalAmount parseTemporalAmount(final String string)
+    {
+        if (NOW.equalsIgnoreCase(string))
+            return Duration.ZERO;
+        final Matcher timeQuantityUnitsMatcher = timeQuantityUnitsPattern.matcher(string);
+        final Map<ChronoUnit, Integer> timeQuantities = new HashMap<>();
+
+        boolean use_period = false;
+        while (timeQuantityUnitsMatcher.find())
+        {
+            final double quantity = "".equals(timeQuantityUnitsMatcher.group(1))
+                    ? 1.0
+                    : Double.valueOf(timeQuantityUnitsMatcher.group(1));
+            final int full = (int) quantity;
+            final double fraction = quantity - full;
+            final String unit = timeQuantityUnitsMatcher.group(2).toLowerCase();
+            // Collect the YEARS, .., DAYS, .., MINUTES, .. as used by Period or Duration.
+            // Problem 1: Need to eventually pick either Period or Duration.
+            //            -> We go up to Period when WEEKS or larger are involved.
+            // Problem 2: They only take full amounts.
+            //            -> We place fractional amounts in the next finer unit.
+            if (unit.startsWith("y"))
+            {
+                timeQuantities.put(YEARS, full);
+                if (fraction > 0)
+                {
+                    final int next = (int) (fraction * 12 + 0.5);
+                    timeQuantities.compute(MONTHS, (u, prev) -> prev == null ? next : prev + next);
+                }
+                use_period = true;
+            }
+            else if (unit.startsWith("mo"))
+            {
+                timeQuantities.compute(MONTHS, (u, prev) -> prev == null ? full : prev + full);
+                if (fraction > 0)
+                {
+                    final int next = (int) (fraction * 4*7 + 0.5);
+                    timeQuantities.compute(DAYS,  (u, prev) -> prev == null ? next : prev + next);
+                }
+                use_period = true;
+            }
+            else if (unit.startsWith("w"))
+            {
+                timeQuantities.compute(WEEKS, (u, prev) -> prev == null ? full : prev + full);
+                if (fraction > 0)
+                {
+                    final int next = (int) (fraction * 7 + 0.5);
+                    timeQuantities.compute(DAYS, (u, prev) -> prev == null ? next : prev + next);
+                }
+                use_period = true;
+            }
+            else if (unit.startsWith("mi"))
+            {
+                timeQuantities.compute(MINUTES, (u, prev) -> prev == null ? full : prev + full);
+                if (fraction > 0)
+                {
+                    final int next = (int) (fraction * 60 + 0.5);
+                    timeQuantities.compute(SECONDS, (u, prev) -> prev == null ? next : prev + next);
+                }
+            }
+            else if (unit.startsWith("h"))
+            {
+                timeQuantities.compute(HOURS, (u, prev) -> prev == null ? full : prev + full);
+                if (fraction > 0)
+                {
+                    final int next = (int) (fraction * 60 + 0.5);
+                    timeQuantities.compute(MINUTES, (u, prev) -> prev == null ? next : prev + next);
+                }
+            }
+            else if (unit.startsWith("d"))
+            {
+                timeQuantities.compute(DAYS, (u, prev) -> prev == null ? full : prev + full);
+                if (fraction > 0)
+                {
+                    final int next = (int) (fraction * 24 + 0.5);
+                    timeQuantities.compute(HOURS, (u, prev) -> prev == null ? next : prev + next);
+                }
+            }
+            else if (unit.startsWith("s"))
+            {
+                timeQuantities.compute(SECONDS, (u, prev) -> prev == null ? full : prev + full);
+                if (fraction > 0)
+                {
+                    final int next = (int) (fraction * 1000 + 0.5);
+                    timeQuantities.compute(MILLIS, (u, prev) -> prev == null ? next : prev + next);
+                }
+            }
+            else if (unit.equals("ms")) {
+                timeQuantities.compute(MILLIS, (u, prev) -> prev == null ? full : prev + full);
+                if (fraction > 0)
+                {
+                    final int next = (int) (fraction * 1000 + 0.5);
+                    timeQuantities.compute(MICROS, (u, prev) -> prev == null ? next : prev + next);
+                }
+            }
+        }
+
+        if (use_period)
+        {
+            Period result = Period.ZERO;
+            if (timeQuantities.containsKey(YEARS))
+                result = result.plusYears(timeQuantities.get(YEARS));
+            if (timeQuantities.containsKey(WEEKS))
+                result = result.plusDays(7*timeQuantities.get(WEEKS));
+            if (timeQuantities.containsKey(MONTHS))
+                result = result.plusMonths(timeQuantities.get(MONTHS));
+            if (timeQuantities.containsKey(DAYS))
+                result = result.plusDays(timeQuantities.get(DAYS));
+            // Ignoring hours, min, .. because they're insignificant compared to weeks
+            return result;
+        }
+        else
+        {
+            Duration result = Duration.ofSeconds(0);
+            for (Entry<ChronoUnit, Integer> entry : timeQuantities.entrySet())
+                result = result.plus(entry.getValue(), entry.getKey());
+            return result;
+        }
+    }
+
+    /** Format a temporal amount
+     *
+     *  @param amount {@link TemporalAmount}
+     *  @return Text like "2 days" that {@link #parseTemporalAmount(String)} can parse
+     */
+    public static String format(final TemporalAmount amount)
+    {
+        final StringBuilder buf = new StringBuilder();
+        if (amount instanceof Period)
+        {
+            final Period period = (Period) amount;
+            if (period.isZero())
+                return NOW;
+
+            if (period.getYears() == 1)
+                buf.append("1 year ");
+            else if (period.getYears() > 1)
+                buf.append(period.getYears()).append(" years ");
+
+            if (period.getMonths() == 1)
+                buf.append("1 month ");
+            else if (period.getMonths() > 0)
+                buf.append(period.getMonths()).append(" months ");
+
+            if (period.getDays() == 1)
+                buf.append("1 day");
+            else if (period.getDays() > 0)
+                buf.append(period.getDays()).append(" days");
+        }
+        else
+        {
+            long secs = ((Duration) amount).getSeconds();
+            if (secs == 0)
+                return NOW;
+
+            int p = (int) (secs / (24*60*60));
+            if (p > 0)
+            {
+                if (p == 1)
+                    buf.append("1 day ");
+                else
+                    buf.append(p).append(" days ");
+                secs -= p * (24*60*60);
+            }
+
+            p = (int) (secs / (60*60));
+            if (p > 0)
+            {
+                if (p == 1)
+                    buf.append("1 hour ");
+                else
+                    buf.append(p).append(" hours ");
+                secs -= p * (60*60);
+            }
+
+            p = (int) (secs / (60));
+            if (p > 0)
+            {
+                if (p == 1)
+                    buf.append("1 minute ");
+                else
+                    buf.append(p).append(" minutes ");
+                secs -= p * (60);
+            }
+
+            if (secs > 0)
+                if (secs == 1)
+                    buf.append("1 second ");
+                else
+                    buf.append(secs).append(" seconds ");
+
+            final int ms = ((Duration)amount).getNano() / 1000000;
+            if (ms > 0)
+                buf.append(ms).append(" ms");
+        }
+        return buf.toString().trim();
+    }
+
+    /** Try to parse text as absolute or relative time
+     *  @param text
+     *  @return {@link Instant}, {@link TemporalAmount} or <code>null</code>
+     */
+    public static Object parseInstantOrTemporalAmount(final String text)
+    {
+        Object result = TimestampFormats.parse(text);
+        if (result != null)
+            return result;
+        return parseTemporalAmount(text);
+    }
+}

--- a/src/main/java/org/phoebus/util/time/TimeRelativeInterval.java
+++ b/src/main/java/org/phoebus/util/time/TimeRelativeInterval.java
@@ -1,0 +1,315 @@
+/**
+ * Copyright (C) 2010-14 diirt developers. See COPYRIGHT.TXT
+ * All rights reserved. Use is subject to license terms. See LICENSE.TXT
+ */
+package org.phoebus.util.time;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.Period;
+import java.time.ZoneOffset;
+import java.time.temporal.TemporalAmount;
+import java.util.Optional;
+
+/**
+ * A period of time where each end can either be an absolute moment in time
+ * (e.g. 5/16/2012 11:30 AM) or a relative moment from a reference (e.g. 30
+ * seconds before) which typically is going to be "now".
+ * <p>
+ * This class stores a reference for start and a reference for end. Each
+ * reference can either be absolute, in which case it's a Instant, or relative,
+ * in which case it's a TimeDuration. The {@link Instant} can be used to
+ * transform the relative interval into an absolute one calculated from the
+ * reference. This allows to keep the relative interval, and then to convert
+ * multiple time to an absolute interval every time that one needs to calculate.
+ * For example, one can keep the range of a plot from 1 minute ago to now, and
+ * then get a specific moment the absolute range of that plot.
+ *
+ * @author carcassi, shroffk
+ */
+@SuppressWarnings("nls")
+public class TimeRelativeInterval {
+
+    private final Object start;
+    private final Object end;
+
+    private TimeRelativeInterval(Object start, Object end) {
+        this.start = start;
+        this.end = end;
+    }
+
+    /**
+     * Create a {@link TimeRelativeInterval} with an absolute start time and an
+     * absolute end time.
+     *
+     * @param start
+     *            the absolute start time of the this time interval
+     * @param end
+     *            the absolute end time of this time interval
+     * @return a {@link TimeRelativeInterval} object starting at Instance start
+     *         and ending at Instance end
+     */
+    public static TimeRelativeInterval of(Instant start, Instant end) {
+        return new TimeRelativeInterval(start, end);
+    }
+
+    /**
+     * Create a {@link TimeRelativeInterval} with a relative start and end
+     * described as either a {@link Duration} or {@link Period}
+     *
+     * e.g. TimeRelativeInterval.of(TimeParser.parse("last 5 days"),
+     * TimeParser.parse("2 days ago"))
+     *
+     * @param start
+     *            the relative start
+     * @param end
+     *            the relative end
+     * @return a
+     */
+    public static TimeRelativeInterval of(TemporalAmount start, TemporalAmount end) {
+        return new TimeRelativeInterval(start, end);
+    }
+
+    /**
+     * Create a {@link TimeRelativeInterval} with a relative start described as
+     * either a {@link Duration} or {@link Period} or "now" and an absolute end
+     * represented by an {@link Instant}
+     *
+     * e.g. TimeRelativeInterval.of(TimeParser.parse("5 days"), Instant.now())
+     *
+     * @param start
+     *            the relative start
+     * @param end
+     *            the absolute end
+     * @return {@link TimeRelativeInterval}
+     */
+    public static TimeRelativeInterval of(TemporalAmount start, Instant end) {
+        return new TimeRelativeInterval(start, end);
+    }
+
+    /**
+     * Create a {@link TimeRelativeInterval} with an absolute start represented
+     * by an {@link Instant} and a relative end described as either a
+     * {@link Duration} or {@link Period} or "now"
+     *
+     * e.g. TimeRelativeInterval.of(TimeParser.parse("2017/01/17 13:45"),
+     * TimeParser.parse("2 days"))
+     *
+     * @param start
+     *            the start instant
+     * @param end
+     *            the relative end time
+     * @return {@link TimeRelativeInterval}
+     */
+    public static TimeRelativeInterval of(Instant start, TemporalAmount end) {
+        return new TimeRelativeInterval(start, end);
+    }
+
+    /**
+     * Create a {@link TimeRelativeInterval} which starts at the absolute
+     * instance "start" and ends at "now"
+     *
+     * @param start
+     *            the absolute start instant
+     * @return {@link TimeRelativeInterval}
+     */
+    public static TimeRelativeInterval startsAt(Instant start) {
+        return new TimeRelativeInterval(start, Duration.ZERO);
+    }
+
+    /**
+     * Create a {@link TimeRelativeInterval} with a relative start and a
+     * relative end "now"
+     *
+     * @param start
+     *            the relative start time defined as a {@link Period} or
+     *            {@link Duration}
+     * @return {@link TimeRelativeInterval}
+     */
+    public static TimeRelativeInterval startsAt(TemporalAmount start) {
+        return new TimeRelativeInterval(start, Duration.ZERO);
+    }
+
+    /**
+     * Create a {@link TimeRelativeInterval} with an absolute end time and a
+     * relative start time which is "now"
+     *
+     * @param end
+     *            the absolute end instant
+     * @return {@link TimeRelativeInterval}
+     */
+    public static TimeRelativeInterval endsAt(Instant end) {
+        return new TimeRelativeInterval(Duration.ZERO, end);
+    }
+
+    /**
+     * Create a {@link TimeRelativeInterval} with a relative end time defined as
+     * a {@link Period} or {@link Duration} adn a relative start "now"
+     *
+     * @param end
+     *            the relative end time
+     * @return {@link TimeRelativeInterval}
+     */
+    public static TimeRelativeInterval endsAt(TemporalAmount end) {
+        return new TimeRelativeInterval(Duration.ZERO, end);
+    }
+
+    /**
+     * Check if the start is absolute
+     *
+     * @return true if the start is defined as an absolute value
+     */
+    public boolean isStartAbsolute() {
+        return start instanceof Instant;
+    }
+
+    /**
+     * Check if the end of the {@link TimeRelativeInterval} is absolute
+     *
+     * @return true if the end is defined as an absolute value
+     */
+    public boolean isEndAbsolute() {
+        return end instanceof Instant;
+    }
+
+    /**
+     * Get the absolute start value of this {@link TimeRelativeInterval}. The
+     * optional is empty if the start value is relative.
+     *
+     * @return {@link Optional} {@link Instant}
+     */
+    public Optional<Instant> getAbsoluteStart() {
+        if (isStartAbsolute()) {
+            return Optional.of((Instant) start);
+        } else {
+            return Optional.empty();
+        }
+    }
+
+    /**
+     * Get the absolute end value of this {@link TimeRelativeInterval}. The
+     * returned Optional is empty is the end value is relative.
+     *
+     * @return {@link Optional} {@link Instant}
+     */
+    public Optional<Instant> getAbsoluteEnd() {
+        if (isEndAbsolute()) {
+            return Optional.of((Instant) end);
+        } else {
+            return Optional.empty();
+        }
+    }
+
+    /**
+     * Get the relative start value of this {@link TimeRelativeInterval}. The
+     * returned Optional is empty is the end value is absolute.
+     *
+     * @return {@link Optional} {@link TemporalAmount}
+     */
+    public Optional<TemporalAmount> getRelativeStart() {
+        if (!isStartAbsolute()) {
+            return Optional.of((TemporalAmount) start);
+        } else {
+            return Optional.empty();
+        }
+    }
+
+    /**
+     * Get the relative start value of this {@link TimeRelativeInterval}. The
+     * returned Optional is empty is the end value is absolute.
+     *
+     * @return {@link Optional} {@link TemporalAmount}
+     */
+    public Optional<TemporalAmount> getRelativeEnd() {
+        if (!isEndAbsolute()) {
+            return Optional.of((TemporalAmount) end);
+        } else {
+            return Optional.empty();
+        }
+    }
+
+    public TimeInterval toAbsoluteInterval(Instant reference) {
+        Instant absoluteStart;
+        Instant absoluteEnd;
+
+        if (isStartAbsolute() && isEndAbsolute()) {
+            // Both start and end are absolute
+            absoluteStart = getAbsoluteStart().get();
+            absoluteEnd = getAbsoluteEnd().get();
+        } else if (isStartAbsolute() && !isEndAbsolute()) {
+            // Start is absolute and end is relative
+            absoluteStart = getAbsoluteStart().get();
+            if (getRelativeEnd().get() instanceof Duration) {
+                if (Duration.ZERO.equals(getRelativeEnd().get())) {
+                    absoluteEnd = Instant.now();
+                } else {
+                    absoluteEnd = getAbsoluteStart().get().plus(getRelativeEnd().get());
+                }
+            } else {
+                absoluteEnd = LocalDateTime.ofInstant(getAbsoluteStart().get(), ZoneOffset.UTC)
+                        .plus(getRelativeEnd().get()).toInstant(ZoneOffset.UTC);
+            }
+        } else if (!isStartAbsolute() && isEndAbsolute()) {
+            // Start is relative and the end is absolute
+            absoluteEnd = getAbsoluteEnd().get();
+            if (getRelativeStart().get() instanceof Duration) {
+                if (Duration.ZERO.equals(getRelativeStart().get())) {
+                    absoluteStart = Instant.now();
+                } else {
+                    absoluteStart = absoluteEnd.minus(getRelativeStart().get());
+                }
+            } else {
+                absoluteStart = LocalDateTime.ofInstant(absoluteEnd, ZoneOffset.UTC).minus(getRelativeStart().get())
+                        .toInstant(ZoneOffset.UTC);
+            }
+        } else {
+            // Both start and end are relative to the reference
+            if (getRelativeStart().get() instanceof Duration) {
+                if (Duration.ZERO.equals(getRelativeStart().get())) {
+                    absoluteStart = Instant.now();
+                } else {
+                    absoluteStart = reference.minus(getRelativeStart().get());
+                }
+            } else {
+                absoluteStart = LocalDateTime.ofInstant(reference, ZoneOffset.UTC).minus(getRelativeStart().get())
+                        .toInstant(ZoneOffset.UTC);
+            }
+            if (getRelativeEnd().get() instanceof Duration) {
+                if (Duration.ZERO.equals(getRelativeEnd().get())) {
+                    absoluteEnd = Instant.now();
+                } else {
+                    absoluteEnd = reference.minus(getRelativeEnd().get());
+                }
+            } else {
+                absoluteEnd = LocalDateTime.ofInstant(reference, ZoneOffset.UTC).minus(getRelativeEnd().get()).toInstant(ZoneOffset.UTC);
+            }
+        }
+        return TimeInterval.between(absoluteStart, absoluteEnd);
+    }
+
+    public TimeInterval toAbsoluteInterval() {
+        return toAbsoluteInterval(Instant.now());
+    }
+
+    /** @return Human-readable representation */
+    @Override
+    public String toString()
+    {
+        final StringBuilder buf = new StringBuilder();
+
+        if (isStartAbsolute())
+            buf.append(TimestampFormats.SECONDS_FORMAT.format((Instant) start));
+        else
+            buf.append(TimeParser.format((TemporalAmount)start));
+
+        buf.append(" - ");
+
+        if (isEndAbsolute())
+            buf.append(TimestampFormats.SECONDS_FORMAT.format((Instant) end));
+        else
+            buf.append(TimeParser.format((TemporalAmount)end));
+
+        return buf.toString();
+    }
+}

--- a/src/main/java/org/phoebus/util/time/TimestampFormats.java
+++ b/src/main/java/org/phoebus/util/time/TimestampFormats.java
@@ -1,0 +1,124 @@
+/*******************************************************************************
+ * Copyright (c) 2016 Oak Ridge National Laboratory.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ ******************************************************************************/
+package org.phoebus.util.time;
+
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+
+/** Time stamp formats
+ *
+ *  <p>Java 8 introduced {@link Instant} which handles time stamps
+ *  with up to nanosecond detail, obsoleting custom classes
+ *  for wrapping control system time stamps.
+ *
+ *  <p>The {@link DateTimeFormatter} is immutable and thread-safe,
+ *  finally allowing re-use of common time stamp formatters.
+ *
+ *  <p>The formatters defined here are suggested for CS-Studio time stamps
+ *  because they can show the full detail of control system time stamps in a portable way,
+ *  independent from locale.
+ *
+ *  @author Kay Kasemir
+ */
+@SuppressWarnings("nls")
+public class TimestampFormats
+{
+    final private static ZoneId zone = ZoneId.systemDefault();
+    final private static String FULL_PATTERN = "yyyy-MM-dd HH:mm:ss.nnnnnnnnn";
+    final private static String MILLI_PATTERN = "yyyy-MM-dd HH:mm:ss.SSS";
+    final private static String SECONDS_PATTERN = "yyyy-MM-dd HH:mm:ss";
+    final private static String DATETIME_PATTERN = "yyyy-MM-dd HH:mm";
+    final private static String DATE_PATTERN = "yyyy-MM-dd";
+    final private static String TIME_PATTERN = "HH:mm:ss";
+
+    /** Time stamp format for 'full' time stamp */
+    final public static DateTimeFormatter FULL_FORMAT= DateTimeFormatter.ofPattern(FULL_PATTERN).withZone(zone);
+
+    /** Time stamp format for time stamp down to milliseconds */
+    final public static DateTimeFormatter MILLI_FORMAT= DateTimeFormatter.ofPattern(MILLI_PATTERN).withZone(zone);
+
+    /** Time stamp format for time stamp up to seconds, but not nanoseconds */
+    final public static DateTimeFormatter SECONDS_FORMAT = DateTimeFormatter.ofPattern(SECONDS_PATTERN).withZone(zone);
+
+    /** Time stamp format for time date and time, no seconds */
+    final public static DateTimeFormatter DATETIME_FORMAT = DateTimeFormatter.ofPattern(DATETIME_PATTERN).withZone(zone);
+
+    /** Time stamp format for time stamp up to seconds, but no date */
+    final public static DateTimeFormatter TIME_FORMAT = DateTimeFormatter.ofPattern(TIME_PATTERN).withZone(zone);
+
+    /** Time stamp format for date, no time */
+    final public static DateTimeFormatter DATE_FORMAT = DateTimeFormatter.ofPattern(DATE_PATTERN).withZone(zone);
+
+    // Internal
+    final private static DateTimeFormatter MONTH_FORMAT = DateTimeFormatter.ofPattern("MM-dd HH:mm").withZone(zone);
+
+    /** Format date and time in a 'compact' way.
+     *
+     *  <p>If the time stamp falls within today, only hours .. seconds are displayed.
+     *  For a time stamp on a different day from today, the date and time without seconds shown.
+     *  For a time in different year, only the date is shown.
+     *
+     *  @param timestamp {@link Instant}
+     *  @return Date and time of the data in preferred text format
+     */
+    public static String formatCompactDateTime(final Instant timestamp)
+    {
+       if (timestamp == null)
+           return "?";
+
+       final LocalDateTime now = LocalDateTime.now();
+       final LocalDateTime local = LocalDateTime.ofInstant(timestamp, zone);
+
+       if (now.getYear() == local.getYear())
+       {
+           // Same day, show time down to HH:mm:ss
+           if (now.getDayOfYear() == local.getDayOfYear())
+               return TIME_FORMAT.format(timestamp);
+           else
+               // Different day, same year, show month, day, down to minutes
+               return MONTH_FORMAT.format(timestamp);
+       }
+       else
+           // Different year, show yyyy-MM-dd";
+           return DATE_FORMAT.format(timestamp);
+   }
+
+    private static final DateTimeFormatter absolute_parsers[] = new DateTimeFormatter[]
+    {
+        TimestampFormats.FULL_FORMAT,
+        TimestampFormats.MILLI_FORMAT,
+        TimestampFormats.SECONDS_FORMAT,
+        TimestampFormats.DATETIME_FORMAT,
+        TimestampFormats.DATE_FORMAT
+    };
+
+    /** Try to parse text as absolute date, time
+     *  @param text Text with date, time
+     *  @return {@link Instant} or <code>null</code>
+     */
+    public static Instant parse(final String text)
+    {
+        for (DateTimeFormatter format : absolute_parsers)
+        {
+            try
+            {
+                // DATE_FORMAT lacks seconds
+                if (format == DATE_FORMAT)
+                    return Instant.from(DATETIME_FORMAT.parse(text + " 00:00"));
+                return Instant.from(format.parse(text));
+            }
+            catch (Throwable ex)
+            {
+                // Ignore
+            }
+        }
+        return null;
+    }
+}

--- a/src/test/java/org/phoebus/util/time/TimeIntervalTest.java
+++ b/src/test/java/org/phoebus/util/time/TimeIntervalTest.java
@@ -1,0 +1,113 @@
+/**
+ * Copyright (C) 2010-14 diirt developers. See COPYRIGHT.TXT
+ * All rights reserved. Use is subject to license terms. See LICENSE.TXT
+ */
+package org.phoebus.util.time;
+
+import org.junit.Test;
+
+import java.time.Instant;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.nullValue;
+import static org.junit.Assert.assertThat;
+
+/**
+ *
+ * @author carcassi
+ */
+public class TimeIntervalTest {
+
+    public TimeIntervalTest() {
+    }
+
+    @Test
+    public void interval1() {
+        TimeInterval interval = TimeInterval.between(Instant.ofEpochSecond(0, 0), Instant.ofEpochSecond(3600, 0));
+        assertThat(interval.getStart(), equalTo(Instant.ofEpochSecond(0, 0)));
+        assertThat(interval.getEnd(), equalTo(Instant.ofEpochSecond(3600, 0)));
+    }
+
+    @Test
+    public void interval2() {
+        TimeInterval interval = TimeInterval.between(Instant.ofEpochSecond(3600, 0), Instant.ofEpochSecond(7200, 0));
+        assertThat(interval.getStart(), equalTo(Instant.ofEpochSecond(3600, 0)));
+        assertThat(interval.getEnd(), equalTo(Instant.ofEpochSecond(7200, 0)));
+    }
+
+    @Test
+    public void interval3() {
+        TimeInterval interval = TimeInterval.between(Instant.ofEpochSecond(0, 0), null);
+        assertThat(interval.getStart(), equalTo(Instant.ofEpochSecond(0, 0)));
+        assertThat(interval.getEnd(), nullValue());
+    }
+
+    @Test
+    public void interval4() {
+        TimeInterval interval = TimeInterval.between(null, Instant.ofEpochSecond(0, 0));
+        assertThat(interval.getStart(), nullValue());
+        assertThat(interval.getEnd(), equalTo(Instant.ofEpochSecond(0, 0)));
+    }
+
+    @Test
+    public void equals1() {
+        TimeInterval interval = TimeInterval.between(Instant.ofEpochSecond(0, 0), Instant.ofEpochSecond(3600, 0));
+        assertThat(interval, equalTo(TimeInterval.between(Instant.ofEpochSecond(0, 0), Instant.ofEpochSecond(3600, 0))));
+    }
+
+    @Test
+    public void equals2() {
+        TimeInterval interval = TimeInterval.between(Instant.ofEpochSecond(0, 1), Instant.ofEpochSecond(3600, 0));
+        assertThat(interval, not(equalTo(TimeInterval.between(Instant.ofEpochSecond(0, 0), Instant.ofEpochSecond(3600, 0)))));
+    }
+
+    @Test
+    public void equals3() {
+        TimeInterval interval = TimeInterval.between(Instant.ofEpochSecond(0, 0), Instant.ofEpochSecond(3600, 1));
+        assertThat(interval, not(equalTo(TimeInterval.between(Instant.ofEpochSecond(0, 0), Instant.ofEpochSecond(3600, 0)))));
+    }
+
+    @Test
+    public void equals4() {
+        TimeInterval interval = TimeInterval.between(Instant.ofEpochSecond(0, 0), null);
+        assertThat(interval, equalTo(TimeInterval.between(Instant.ofEpochSecond(0, 0), null)));
+    }
+
+    @Test
+    public void equals5() {
+        TimeInterval interval = TimeInterval.between(null, Instant.ofEpochSecond(0, 0));
+        assertThat(interval, equalTo(TimeInterval.between(null, Instant.ofEpochSecond(0, 0))));
+    }
+
+    @Test
+    public void contains1() {
+        TimeInterval interval = TimeInterval.between(Instant.ofEpochSecond(0, 0), Instant.ofEpochSecond(3600, 1));
+        assertThat(interval.contains(Instant.ofEpochSecond(3,0)), is(true));
+        assertThat(interval.contains(Instant.ofEpochSecond(0,110)), is(true));
+        assertThat(interval.contains(Instant.ofEpochSecond(3600,0)), is(true));
+        assertThat(interval.contains(Instant.ofEpochSecond(-1,110)), is(false));
+        assertThat(interval.contains(Instant.ofEpochSecond(3600,2)), is(false));
+    }
+
+    @Test
+    public void contains2() {
+        TimeInterval interval = TimeInterval.between(Instant.ofEpochSecond(0, 0), null);
+        assertThat(interval.contains(Instant.ofEpochSecond(-3600,2)), is(false));
+        assertThat(interval.contains(Instant.ofEpochSecond(-1,110)), is(false));
+        assertThat(interval.contains(Instant.ofEpochSecond(0,110)), is(true));
+        assertThat(interval.contains(Instant.ofEpochSecond(3,0)), is(true));
+        assertThat(interval.contains(Instant.ofEpochSecond(3600,0)), is(true));
+    }
+
+    @Test
+    public void contains3() {
+        TimeInterval interval = TimeInterval.between(null, Instant.ofEpochSecond(0, 0));
+        assertThat(interval.contains(Instant.ofEpochSecond(-3600,2)), is(true));
+        assertThat(interval.contains(Instant.ofEpochSecond(-1,110)), is(true));
+        assertThat(interval.contains(Instant.ofEpochSecond(0,110)), is(false));
+        assertThat(interval.contains(Instant.ofEpochSecond(3,0)), is(false));
+        assertThat(interval.contains(Instant.ofEpochSecond(3600,0)), is(false));
+    }
+}

--- a/src/test/java/org/phoebus/util/time/TimeParserTest.java
+++ b/src/test/java/org/phoebus/util/time/TimeParserTest.java
@@ -1,0 +1,188 @@
+/**
+ * Copyright (C) 2010-14 diirt developers. See COPYRIGHT.TXT
+ * All rights reserved. Use is subject to license terms. See LICENSE.TXT
+ */
+package org.phoebus.util.time;
+
+import org.junit.Test;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.Period;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
+import java.time.temporal.TemporalAmount;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * TODO additional tests are needed to verify all the chrono types are properly handled.
+ * @author shroffk
+ */
+@SuppressWarnings("nls")
+public class TimeParserTest {
+
+    @Test
+    public void parse() {
+        Instant now = Instant.now();
+        // create time interval using string to define relative start and end
+        // times
+        TimeRelativeInterval interval = TimeRelativeInterval.of(TimeParser.parseTemporalAmount("1 min"), now);
+        assertEquals(now.minusSeconds(60), interval.toAbsoluteInterval().getStart());
+        assertEquals(now, interval.toAbsoluteInterval().getEnd());
+    }
+
+    /**
+     * Test the creation parsing of string representations of time to create {@link TimeRelativeInterval}
+     *
+     * The below tests create an interval which represents a single month.
+     *
+     */
+    @Test
+    public void parseRelativeInterval() {
+        // Create an interval for January
+        TimeRelativeInterval interval = TimeRelativeInterval.of(TimeParser.parseTemporalAmount("1 month"), LocalDateTime
+                .parse("2011-02-01T00:00:00", DateTimeFormatter.ISO_LOCAL_DATE_TIME).toInstant(ZoneOffset.UTC));
+
+        // Check jan it is 31 days
+        TimeInterval jan = interval.toAbsoluteInterval();
+        assertEquals(31L, Duration.between(jan.getStart(), jan.getEnd()).toDays());
+
+        // Check February is 28 days
+        TimeInterval feb = TimeRelativeInterval
+                .of(TimeParser.parseTemporalAmount("1 month"), LocalDateTime
+                        .parse("2011-03-01T00:00:00", DateTimeFormatter.ISO_LOCAL_DATE_TIME).toInstant(ZoneOffset.UTC))
+                .toAbsoluteInterval();
+        assertEquals(28L, Duration.between(feb.getStart(), feb.getEnd()).toDays());
+
+        // Check February is 29 days because it is a leap year
+        TimeInterval leapFeb = TimeRelativeInterval
+                .of(TimeParser.parseTemporalAmount("1 month"), LocalDateTime
+                        .parse("2012-03-01T00:00:00", DateTimeFormatter.ISO_LOCAL_DATE_TIME).toInstant(ZoneOffset.UTC))
+                .toAbsoluteInterval();
+        assertEquals(29L, Duration.between(leapFeb.getStart(), leapFeb.getEnd()).toDays());
+    }
+
+    @Test
+    public void testParseTemporalAmount()
+    {
+        TemporalAmount amount = TimeParser.parseTemporalAmount("3 days");
+        long seconds = LocalDateTime.ofEpochSecond(0, 0, ZoneOffset.UTC).plus(amount).toEpochSecond(ZoneOffset.UTC);
+        assertEquals(3*24*60*60, seconds);
+
+        amount = TimeParser.parseTemporalAmount("3 days 20 mins 10 sec");
+        seconds = LocalDateTime.ofEpochSecond(0, 0, ZoneOffset.UTC).plus(amount).toEpochSecond(ZoneOffset.UTC);
+        assertEquals(3*24*60*60 + 20*60 + 10, seconds);
+
+        amount = TimeParser.parseTemporalAmount("now");
+        seconds = LocalDateTime.ofEpochSecond(0, 0, ZoneOffset.UTC).plus(amount).toEpochSecond(ZoneOffset.UTC);
+        assertEquals(0, seconds);
+
+        // Month triggers use of period, which only keeps y/m/d
+        // 1 week adds 7 days
+        amount = TimeParser.parseTemporalAmount("1 month 1 weeks 3 days 20 mins 10 sec");
+        assertEquals(amount, Period.of(0, 1, 10));
+
+        amount = TimeParser.parseTemporalAmount("1 month 1 day");
+        assertEquals(amount, Period.of(0, 1, 1));
+
+        amount = TimeParser.parseTemporalAmount("1 mo");
+        assertEquals(amount, Period.of(0, 1, 0));
+
+        // Just the unit name implies "1 xxx"
+        amount = TimeParser.parseTemporalAmount("month");
+        assertEquals(amount, Period.of(0, 1, 0));
+
+        // 60 days span more than a month,
+        // but since "month" is not mentioned,
+        // it's considered 60 exact days
+        // (implying 24 hour days)
+        amount = TimeParser.parseTemporalAmount("60 days");
+        assertEquals(amount, Duration.ofDays(60));
+    }
+
+    @Test
+    public void testParseFactionalTemporalAmount()
+    {
+        // Just having ".0" used to be an error before fractions were supported
+        TemporalAmount amount = TimeParser.parseTemporalAmount("1.000 hour");
+        System.out.println(TimeParser.format(amount));
+        Instant instant = Instant.ofEpochSecond(0).plus(amount);
+        assertEquals(60*60, instant.getEpochSecond());
+        assertEquals(0, instant.getNano());
+
+        amount = TimeParser.parseTemporalAmount("1.5 hour");
+        System.out.println(TimeParser.format(amount));
+        instant = Instant.ofEpochSecond(0).plus(amount);
+        assertEquals((60+30)*60, instant.getEpochSecond());
+        assertEquals(0, instant.getNano());
+
+        amount = TimeParser.parseTemporalAmount("1.5 hour 6.5 minutes");
+        System.out.println(TimeParser.format(amount));
+        instant = Instant.ofEpochSecond(0).plus(amount);
+        assertEquals((60+30+6)*60+30, instant.getEpochSecond());
+        assertEquals(0, instant.getNano());
+
+        amount = TimeParser.parseTemporalAmount("6.5 minutes");
+        System.out.println(TimeParser.format(amount));
+        instant = Instant.ofEpochSecond(0).plus(amount);
+        assertEquals(6*60+30, instant.getEpochSecond());
+        assertEquals(0, instant.getNano());
+
+        amount = TimeParser.parseTemporalAmount("3.5 seconds");
+        System.out.println(TimeParser.format(amount));
+        instant = Instant.ofEpochSecond(0).plus(amount);
+        assertEquals(3, instant.getEpochSecond());
+        assertEquals(500000000, instant.getNano());
+
+        amount = TimeParser.parseTemporalAmount("3.5 ms");
+        System.out.println(TimeParser.format(amount));
+        instant = Instant.ofEpochSecond(0).plus(amount);
+        assertEquals(0, instant.getEpochSecond());
+        assertEquals(3500000, instant.getNano());
+
+        amount = TimeParser.parseTemporalAmount("1.5 days");
+        System.out.println(TimeParser.format(amount));
+        instant = Instant.ofEpochSecond(0).plus(amount);
+        assertEquals((24+12)*60*60, instant.getEpochSecond());
+        assertEquals(0, instant.getNano());
+
+        // As soon as the time span enters "weeks", it's handled
+        // as a 'Period' which is only good down to days.
+        // So 1.5 weeks = 7 + 3.5 days is rounded to 11 days, not 10.5
+        amount = TimeParser.parseTemporalAmount("1.5 weeks");
+        System.out.println(TimeParser.format(amount));
+        assertEquals(Period.of(0,  0,  11), amount);
+
+        // 1.5 month = 1 month, 2 weeks=14days
+        amount = TimeParser.parseTemporalAmount("1.5 months");
+        System.out.println(TimeParser.format(amount));
+        assertEquals(Period.of(0,  1,  14), amount);
+
+        // 1.5 years = 1 year, 6 months (not divving up further into days)
+        amount = TimeParser.parseTemporalAmount("1.5 years");
+        System.out.println(TimeParser.format(amount));
+        assertEquals(Period.of(1,  6,  0), amount);
+    }
+
+    @Test
+    public void testFormatTemporalAmount()
+    {
+        String text = TimeParser.format(Duration.ofHours(2));
+        assertEquals("2 hours", text);
+
+        text = TimeParser.format(Period.of(1, 2, 3));
+        assertEquals("1 year 2 months 3 days", text);
+
+        text = TimeParser.format(Duration.ofSeconds(2*24*60*60 + 1*60*60 + 10, 123000000L));
+        assertEquals("2 days 1 hour 10 seconds 123 ms", text);
+
+        text = TimeParser.format(Duration.ofSeconds(0));
+        assertEquals("now", text);
+
+        text = TimeParser.format(Period.ZERO);
+        assertEquals("now", text);
+    }
+}

--- a/src/test/java/org/phoebus/util/time/TimeRelativeIntervalTest.java
+++ b/src/test/java/org/phoebus/util/time/TimeRelativeIntervalTest.java
@@ -1,0 +1,178 @@
+/**
+ * Copyright (C) 2010-14 diirt developers. See COPYRIGHT.TXT
+ * All rights reserved. Use is subject to license terms. See LICENSE.TXT
+ */
+package org.phoebus.util.time;
+
+import org.junit.Test;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
+
+import static java.time.Duration.ofHours;
+import static java.time.Duration.ofMillis;
+import static java.time.Duration.ofMinutes;
+import static java.time.Duration.ofSeconds;
+import static java.time.Period.ofMonths;
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
+
+/**
+ *
+ * @author carcassi, shroffk
+ */
+public class TimeRelativeIntervalTest {
+
+    public TimeRelativeIntervalTest() {
+    }
+
+    /**
+     * Absolute start and absolute end
+     */
+    @Test
+    public void interval1() {
+        TimeRelativeInterval interval = TimeRelativeInterval.of(Instant.ofEpochSecond(0, 0),
+                Instant.ofEpochSecond(3600, 0));
+        assertThat(interval.toAbsoluteInterval(Instant.now()),
+                equalTo(TimeInterval.between(Instant.ofEpochSecond(0, 0), Instant.ofEpochSecond(3600, 0))));
+    }
+
+    /**
+     * absolute start and relative end
+     */
+    @Test
+    public void interval2() {
+        // relative end of 10 ns after start
+        TimeRelativeInterval interval = TimeRelativeInterval.of(Instant.ofEpochSecond(0, 0), Duration.ofNanos(10));
+        assertThat(interval.toAbsoluteInterval(),
+                equalTo(TimeInterval.between(Instant.ofEpochSecond(0, 0), Instant.ofEpochSecond(0, 10))));
+        // relatice end of 10 ms after start
+        interval = TimeRelativeInterval.of(Instant.ofEpochSecond(0, 0), Duration.ofMillis(10));
+        assertThat(interval.toAbsoluteInterval(),
+                equalTo(TimeInterval.between(Instant.ofEpochSecond(0, 0), Instant.ofEpochSecond(0, 10000000))));
+        // relative end of 10 s after start
+        interval = TimeRelativeInterval.of(Instant.ofEpochSecond(0, 0), Duration.ofSeconds(10));
+        assertThat(interval.toAbsoluteInterval(),
+                equalTo(TimeInterval.between(Instant.ofEpochSecond(0, 0), Instant.ofEpochSecond(10, 0))));
+        // relative end of 10 mins after start
+        interval = TimeRelativeInterval.of(Instant.ofEpochSecond(0, 0), Duration.ofMinutes(10));
+        assertThat(interval.toAbsoluteInterval(Instant.now()),
+                equalTo(TimeInterval.between(Instant.ofEpochSecond(0, 0), Instant.ofEpochSecond(10 * 60, 0))));
+        // relative end of 10 hours after start
+        interval = TimeRelativeInterval.of(Instant.ofEpochSecond(0, 0), Duration.ofHours(10));
+        assertThat(interval.toAbsoluteInterval(Instant.now()),
+                equalTo(TimeInterval.between(Instant.ofEpochSecond(0, 0), Instant.ofEpochSecond(10 * 60 * 60, 0))));
+    }
+
+    /**
+     * relative start and absolute end
+     */
+    @Test
+    public void interval3() {
+        // relative start of 10 ns before now
+        Instant now = Instant.now();
+        TimeRelativeInterval interval = TimeRelativeInterval.of(Duration.ofNanos(10), now);
+        assertThat(interval.toAbsoluteInterval(), equalTo(TimeInterval.between(now.minusNanos(10), now)));
+        // relative start of 10 ms before now
+        interval = TimeRelativeInterval.of(Duration.ofMillis(10), now);
+        assertThat(interval.toAbsoluteInterval(), equalTo(TimeInterval.between(now.minusMillis(10), now)));
+        // relative start of 10 s before now
+        interval = TimeRelativeInterval.of(Duration.ofSeconds(10), now);
+        assertThat(interval.toAbsoluteInterval(), equalTo(TimeInterval.between(now.minusSeconds(10), now)));
+        // relative start of 10 mins before now
+        interval = TimeRelativeInterval.of(Duration.ofMinutes(10), now);
+        assertThat(interval.toAbsoluteInterval(), equalTo(TimeInterval.between(now.minusSeconds(10*60), now)));
+        // relative start of 10 hours before now
+        interval = TimeRelativeInterval.of(Duration.ofHours(10), now);
+        assertThat(interval.toAbsoluteInterval(), equalTo(TimeInterval.between(now.minusSeconds(10*60*60), now)));
+    }
+
+    @Test
+    public void relativeIntervalinMilliSecs() {
+        TimeRelativeInterval interval = TimeRelativeInterval.of(ofMillis(15), ofMillis(5));
+        Instant now = Instant.now();
+        TimeInterval timeInterval = interval.toAbsoluteInterval(now);
+        TimeInterval expectedTimeInterval = TimeInterval.between(now.minus(ofMillis(15)), now.minus(ofMillis(5)));
+        assertEquals(expectedTimeInterval, timeInterval);
+    }
+
+    @Test
+    public void relativeIntervalinSecs() {
+        TimeRelativeInterval interval = TimeRelativeInterval.of(ofSeconds(5), ofSeconds(3));
+        Instant now = Instant.now();
+        TimeInterval timeInterval = interval.toAbsoluteInterval(now);
+        TimeInterval expectedTimeInterval = TimeInterval.between(now.minus(ofSeconds(5)), now.minus(ofSeconds(3)));
+        assertEquals(expectedTimeInterval, timeInterval);
+    }
+
+    @Test
+    public void relativeIntervalinMins() {
+        TimeRelativeInterval interval = TimeRelativeInterval.of(ofMinutes(5), ofMinutes(3));
+        Instant now = Instant.now();
+        TimeInterval timeInterval = interval.toAbsoluteInterval(now);
+        TimeInterval expectedTimeInterval = TimeInterval.between(now.minus(ofMinutes(5)), now.minus(ofMinutes(3)));
+        assertEquals(expectedTimeInterval, timeInterval);
+    }
+
+    @Test
+    public void relativeIntervalinHours() {
+        TimeRelativeInterval interval = TimeRelativeInterval.of(ofHours(5), ofHours(3));
+        Instant now = Instant.now();
+        TimeInterval timeInterval = interval.toAbsoluteInterval(now);
+        TimeInterval expectedTimeInterval = TimeInterval.between(now.minus(ofHours(5)), now.minus(ofHours(3)));
+        assertEquals(expectedTimeInterval, timeInterval);
+    }
+
+    /**
+     * The {@link TimeRelativeInterval} is defined with both the start and the
+     * end as relative definition. The below tests create an interval which
+     * represents a single month.
+     * 
+     */
+    @Test
+    public void relativeIntervalinDays1() {
+        // Create an interval for January
+        TimeRelativeInterval interval = TimeRelativeInterval.of(ofMonths(1), ofMonths(0));
+        // Check jan it is 31 days
+        TimeInterval jan = interval.toAbsoluteInterval(LocalDateTime
+                .parse("2011-02-01T00:00:00", DateTimeFormatter.ISO_LOCAL_DATE_TIME).toInstant(ZoneOffset.UTC));
+        assertEquals(31L, Duration.between(jan.getStart(), jan.getEnd()).toDays());
+
+        // Check February is 28 days
+        TimeInterval feb = interval.toAbsoluteInterval(LocalDateTime
+                .parse("2011-03-01T00:00:00", DateTimeFormatter.ISO_LOCAL_DATE_TIME).toInstant(ZoneOffset.UTC));
+        assertEquals(28L, Duration.between(feb.getStart(), feb.getEnd()).toDays());
+
+        // Check February is 29 days because it is a leap year
+        TimeInterval leapFeb = interval.toAbsoluteInterval(LocalDateTime
+                .parse("2012-03-01T00:00:00", DateTimeFormatter.ISO_LOCAL_DATE_TIME).toInstant(ZoneOffset.UTC));
+        assertEquals(29L, Duration.between(leapFeb.getStart(), leapFeb.getEnd()).toDays());
+    }
+
+    public void relativeIntervalinDays2() {
+        // Create an interval for January
+        TimeRelativeInterval interval = TimeRelativeInterval.of(LocalDateTime
+                .parse("2011-01-01T00:00:00", DateTimeFormatter.ISO_LOCAL_DATE_TIME).toInstant(ZoneOffset.UTC),
+                ofMonths(1));
+        // Check jan it is 31 days
+        TimeInterval jan = interval.toAbsoluteInterval();
+        assertEquals(31L, Duration.between(jan.getStart(), jan.getEnd()).toDays());
+        interval = TimeRelativeInterval.of(LocalDateTime
+                .parse("2011-02-01T00:00:00", DateTimeFormatter.ISO_LOCAL_DATE_TIME).toInstant(ZoneOffset.UTC),
+                ofMonths(1));
+        // Check February is 28 days
+        TimeInterval feb = interval.toAbsoluteInterval();
+        assertEquals(28L, Duration.between(feb.getStart(), feb.getEnd()).toDays());
+        interval = TimeRelativeInterval.of(LocalDateTime
+                .parse("2012-02-01T00:00:00", DateTimeFormatter.ISO_LOCAL_DATE_TIME).toInstant(ZoneOffset.UTC),
+                ofMonths(1));
+        // Check February is 29 days because it is a leap year
+        TimeInterval leapFeb = interval.toAbsoluteInterval();
+        assertEquals(29L, Duration.between(leapFeb.getStart(), leapFeb.getEnd()).toDays());
+    }
+
+}


### PR DESCRIPTION
In order to support date/time expressions like "12 hours" or "2 days" across all clients, I've added parsing code copied from the Phoebus project. Of course a maven dependency would be preferable...

The change is backwards compatible, i.e. client may choose to perform the same parsing of such expressions, but server will call the parsing code anyway.