### PR TITLE
Add pre-processors to convert markup to plain text

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -115,6 +115,12 @@
       <version>4.4</version>
     </dependency>
 
+    <dependency>
+      <groupId>com.atlassian.commonmark</groupId>
+      <artifactId>commonmark</artifactId>
+      <version>0.15.2</version>
+    </dependency>
+
 
     <dependency>
       <groupId>org.projectlombok</groupId>

--- a/src/main/java/gov/bnl/olog/PreProcessorConfig.java
+++ b/src/main/java/gov/bnl/olog/PreProcessorConfig.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (C) 2020 European Spallation Source ERIC.
+ *
+ *  This program is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU General Public License
+ *  as published by the Free Software Foundation; either version 2
+ *  of the License, or (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program; if not, write to the Free Software
+ *  Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+ */
+
+package gov.bnl.olog;
+
+import gov.bnl.olog.entity.preprocess.CommonmarkPreprocessor;
+import gov.bnl.olog.entity.preprocess.DefaultPreprocessor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class PreProcessorConfig {
+
+    @Bean
+    public DefaultPreprocessor defaultPreprocessor(){
+        return new DefaultPreprocessor();
+    }
+
+    @Bean
+    public CommonmarkPreprocessor commonmarkPreprocessor(){
+        return new CommonmarkPreprocessor();
+    }
+}

--- a/src/main/java/gov/bnl/olog/entity/Log.java
+++ b/src/main/java/gov/bnl/olog/entity/Log.java
@@ -12,6 +12,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import org.springframework.data.annotation.Id;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreType;

--- a/src/main/java/gov/bnl/olog/entity/preprocess/CommonmarkPreprocessor.java
+++ b/src/main/java/gov/bnl/olog/entity/preprocess/CommonmarkPreprocessor.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (C) 2020 European Spallation Source ERIC.
+ *
+ *  This program is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU General Public License
+ *  as published by the Free Software Foundation; either version 2
+ *  of the License, or (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program; if not, write to the Free Software
+ *  Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+ */
+
+package gov.bnl.olog.entity.preprocess;
+
+import gov.bnl.olog.entity.Log;
+import org.commonmark.node.Node;
+import org.commonmark.parser.Parser;
+import org.commonmark.renderer.text.TextContentRenderer;
+
+public class CommonmarkPreprocessor implements LogPreprocessor{
+
+    private TextContentRenderer textContentRenderer = TextContentRenderer.builder().build();
+    private Parser parser = Parser.builder().build();
+
+    /**
+     * Processes the log entry under the assumption that the source field of a {@link Log} object
+     * as posted by client is always null, i.e. client does not set the field. This method treats the
+     * description field as a Commonmark source and copies it to the source field. Then the same
+     * string is processed to set the description field to a "plain text" variant of the Commonmark source.
+     * @param log
+     * @return The processed log record.
+     */
+    @Override
+    public Log process(Log log){
+        if(log.getDescription() != null){ // Should not be null, but clients cannot be trusted.
+            log.setSource(log.getDescription());
+            Node document = parser.parse(log.getDescription());
+            String plainText = textContentRenderer.render(document);
+            log.setDescription(plainText);
+            return log;
+        }
+        return log;
+    }
+}

--- a/src/main/java/gov/bnl/olog/entity/preprocess/DefaultPreprocessor.java
+++ b/src/main/java/gov/bnl/olog/entity/preprocess/DefaultPreprocessor.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (C) 2020 European Spallation Source ERIC.
+ *
+ *  This program is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU General Public License
+ *  as published by the Free Software Foundation; either version 2
+ *  of the License, or (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program; if not, write to the Free Software
+ *  Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+ */
+
+package gov.bnl.olog.entity.preprocess;
+
+import gov.bnl.olog.entity.Log;
+
+/**
+ * Default implementation of {@link LogPreprocessor}.
+ */
+public class DefaultPreprocessor implements LogPreprocessor{
+
+    /**
+     * Processes the log entry under the assumption that the source field of a {@link Log} object
+     * as posted by client is always null, i.e. client does not set the field. Consequently this
+     * method copies the description field to the source field.
+     * @param log
+     * @return The processed log record.
+     */
+    @Override
+    public Log process(Log log){
+        log.setSource(log.getDescription());
+        return log;
+    }
+}

--- a/src/main/java/gov/bnl/olog/entity/preprocess/LogPreprocessor.java
+++ b/src/main/java/gov/bnl/olog/entity/preprocess/LogPreprocessor.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (C) 2020 European Spallation Source ERIC.
+ *
+ *  This program is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU General Public License
+ *  as published by the Free Software Foundation; either version 2
+ *  of the License, or (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program; if not, write to the Free Software
+ *  Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+ */
+
+package gov.bnl.olog.entity.preprocess;
+
+import gov.bnl.olog.entity.Log;
+
+/**
+ * A pre-processor interface intended to ensure that all fields in the log entry have sensible values before
+ * the entry is persisted.
+ */
+public interface LogPreprocessor {
+
+    /**
+     * Processes the log entry and returns a processed value.
+     * @param log
+     * @return
+     */
+    Log process(Log log);
+}

--- a/src/test/java/gov/bnl/olog/entity/preprocess/CommonmarkPreprocessorTest.java
+++ b/src/test/java/gov/bnl/olog/entity/preprocess/CommonmarkPreprocessorTest.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (C) 2020 European Spallation Source ERIC.
+ *
+ *  This program is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU General Public License
+ *  as published by the Free Software Foundation; either version 2
+ *  of the License, or (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program; if not, write to the Free Software
+ *  Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+ */
+
+package gov.bnl.olog.entity.preprocess;
+
+import gov.bnl.olog.entity.Log;
+import gov.bnl.olog.entity.Log.LogBuilder;
+import gov.bnl.olog.entity.preprocess.CommonmarkPreprocessor;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class CommonmarkPreprocessorTest {
+
+    private CommonmarkPreprocessor commonmarkPreprocessor = new CommonmarkPreprocessor();
+
+    @Test
+    public void testDescriptionNonNull(){
+        Log log = LogBuilder.createLog()
+                .description("**BOLD** ![alt](http://foo.bar)")
+                .source(null)
+                .build();
+
+        log = commonmarkPreprocessor.process(log);
+        assertEquals("**BOLD** ![alt](http://foo.bar)", log.getSource());
+        assertEquals("BOLD \"alt\" (http://foo.bar)", log.getDescription());
+
+    }
+
+    @Test
+    public void testDescriptionNull(){
+        Log log = LogBuilder.createLog()
+                .description(null)
+                .source(null)
+                .build();
+
+        log = commonmarkPreprocessor.process(log);
+        assertEquals("", log.getSource());
+        assertEquals("", log.getDescription());
+
+    }
+}

--- a/src/test/java/gov/bnl/olog/entity/preprocess/DefaultPreprocessorTest.java
+++ b/src/test/java/gov/bnl/olog/entity/preprocess/DefaultPreprocessorTest.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (C) 2020 European Spallation Source ERIC.
+ *
+ *  This program is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU General Public License
+ *  as published by the Free Software Foundation; either version 2
+ *  of the License, or (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program; if not, write to the Free Software
+ *  Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+ */
+
+package gov.bnl.olog.entity.preprocess;
+
+import gov.bnl.olog.entity.Log;
+import gov.bnl.olog.entity.Log.LogBuilder;
+import gov.bnl.olog.entity.preprocess.DefaultPreprocessor;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class DefaultPreprocessorTest {
+
+    private DefaultPreprocessor defaultPreprocessor = new DefaultPreprocessor();
+
+    @Test
+    public void testSourceNull(){
+        Log log = LogBuilder.createLog()
+                .description("description")
+                .source(null)
+                .build();
+
+        log = defaultPreprocessor.process(log);
+        assertEquals("description", log.getSource());
+        assertEquals("description", log.getDescription());
+    }
+}


### PR DESCRIPTION
In order to ensure that both description and source fields are set correctly, I've added "pre-processors". One is used for clients that do not use markup, the other is for Commonmark. To make this work as intended for the Commonmark case, client will need to send request parameter `markup=commonmark`. 

The implementation relies on the fact that clients currently do not set the source field, i.e. any text - whether using markup or not - is provided in the description field of the Log class.

The web client is updated to use the proper request parameter value, the Phoebus client is pending a PR.